### PR TITLE
refactor: simplify pipeline prototype and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,265 +1,177 @@
+# Portable, self-healing Makefile (no heredocs, no duplicate targets)
 
-# ===== User-configurable defaults =====
-IMAGE_REG ?= data-model-pipeline
-TAG       ?= dev
-REF       ?= main
-SUBDIR    ?=
-PORTABLE  ?=
+IMAGE ?= eopf-geozarr:dev
+ARGO_VER ?= v3.6.5
+ARGO_INSTALL_URL ?= https://github.com/argoproj/argo-workflows/releases/download/$(ARGO_VER)/install.yaml
 NAMESPACE ?= argo
-CLUSTER   ?= k3s-default
+PVC_NAME ?= geozarr-pvc
+PORTABLE_BUILD ?= 0
+BASE_IMAGE ?= python:3.11-slim
+RUNTIME_BASE_IMAGE ?= python:3.11-slim
+DM_RAW_BASE ?= https://raw.githubusercontent.com/EOPF-Explorer/data-model
+EOPF_GEOZARR_REF ?= main
+EOPF_GEOZARR_SUBDIR ?=
+BUILD_FLAGS ?=
+CACHE_BUST := $(shell date +%s)
+CLUSTER ?= k3s-default
+REMOTE_PATH ?= /data
+LOCAL_DIR ?= ./out
 
-HOST_ARCH := $(shell uname -m)
-ifeq ($(HOST_ARCH),arm64)
-  PLATFORM ?= linux/arm64
-else ifeq ($(HOST_ARCH),aarch64)
-  PLATFORM ?= linux/arm64
-else
-  PLATFORM ?= linux/amd64
-endif
-ifeq ($(PLATFORM),linux/arm64)
-  PORTABLE ?= 1
-endif
+.PHONY: up up-fast up-rebuild build rebuild image-import ensure-pvc template apply submit logs logs-pod pod fetch status down env doctor
 
-DOCKERFILE ?= $(shell [ -f docker/Dockerfile ] && echo docker/Dockerfile || echo Dockerfile)
+up: bootstrap cluster argo-install build image-import ensure-pvc template submit
+	# full local run: bootstrap → cluster → argo → build → import → pvc → template → submit
 
-STAMP      := $(shell date -u +%Y%m%d%H%M%S)
-IMMUTABLE  ?= 0   # stable tags by default; override with IMMUTABLE=1 in CI
-NC         ?= 0   # use cached layers unless forced
-PULL       ?= 0   # don’t pull unless forced
+up-fast: build image-import template submit
 
-IMAGE_BASE := $(IMAGE_REG):$(TAG)
-ifeq ($(IMMUTABLE),1)
-  IMAGE := $(IMAGE_REG):$(TAG)-$(STAMP)
-else
-  IMAGE := $(IMAGE_BASE)
-endif
+up-rebuild:
+	$(MAKE) rebuild
+	-$(MAKE) image-import
+	$(MAKE) template
+	$(MAKE) submit
 
-ifneq (,$(findstring /,$(IMAGE)))
-  PULLPOL := Always
-else
-  PULLPOL := IfNotPresent
-endif
+build:
+	# docker build eopf-geozarr:dev image
+	@echo "Building image $(IMAGE) ..."
+	docker build $(BUILD_FLAGS) \
+	  --build-arg BASE_IMAGE=$(BASE_IMAGE) \
+	  --build-arg RUNTIME_BASE_IMAGE=$(RUNTIME_BASE_IMAGE) \
+	  --build-arg PORTABLE_BUILD=$(PORTABLE_BUILD) \
+	  --build-arg EOPF_GEOZARR_REF=$(EOPF_GEOZARR_REF) \
+	  --build-arg EOPF_GEOZARR_SUBDIR=$(EOPF_GEOZARR_SUBDIR) \
+	  --build-arg DM_RAW_BASE=$(DM_RAW_BASE) \
+	  --build-arg CACHE_BUST=$(CACHE_BUST) \
+	  -f docker/Dockerfile -t $(IMAGE) .
 
-TPL       ?= workflows/geozarr-convert-template.yaml
-PARAMS    ?= params.json
-WORKDIR   ?= .work
+rebuild:
+	$(MAKE) build BUILD_FLAGS="--no-cache --pull"
 
-STAC_URL    ?=
-OUTPUT_ZARR ?=
-ZARR_GROUPS ?=
-DEFAULT_PULLPOL := $(if $(findstring /,$(IMAGE)),Always,IfNotPresent)
-PULLPOL ?= $(DEFAULT_PULLPOL)
-
-LOAD_STRATEGY ?= auto
-
-.PHONY: help build push load load-k3d load-minikube build-in-minikube \
-        argo-install template apply dev submit submit-cli submit-api status \
-        latest logs-save clean _ensure-dirs fetch-tar run clean-pvc \
-        print-config print-image
-
-help:
-	@echo "Targets:"
-	@echo "  build            Build image (PORTABLE=1 for system GDAL/PROJ)."
-	@echo "  load             Auto-load into k3d/minikube (or push, if configured)."
-	@echo "  apply            Build + load + install Argo + template."
-	@echo "  dev              Build + load + template (fast local loop)."
-	@echo "  submit           Submit workflow with params.json or env overrides."
-	@echo "  submit-cli       CLI submission shortcut."
-	@echo "  submit-api       API submission shortcut."
-	@echo "  status           Show workflow status."
-	@echo "  fetch-tar        Fetch results from PVC."
-
-print-config:
-	@echo "IMAGE_BASE = $(IMAGE_BASE)"
-	@echo "IMAGE      = $(IMAGE)"
-	@echo "PULLPOL    = $(PULLPOL)"
-	@echo "IMMUTABLE  = $(IMMUTABLE)"
-	@echo "REF        = $(REF)"
-	@echo "SUBDIR     = $(SUBDIR)"
-	@echo "PORTABLE   = $(PORTABLE)"
-	@echo "PLATFORM   = $(PLATFORM)"
-	@echo "DOCKERFILE = $(DOCKERFILE)"
-	@echo "NAMESPACE  = $(NAMESPACE)"
-	@echo "CLUSTER    = $(CLUSTER)"
-	@echo "TPL        = $(TPL)"
-	@echo "PARAMS     = $(PARAMS)"
-	@echo "NC(--no-cache) = $(NC)"
-	@echo "PULL(--pull)   = $(PULL)"
-	@echo "LOAD_STRATEGY  = $(LOAD_STRATEGY)"
-
-print-image:
-	@echo "$(IMAGE)"
-
-# ===== Build =====
-build: print-image
-	@if [ "$(PORTABLE)" = "1" ]; then \
-	  echo "==> Building PORTABLE image (ref=$(REF), subdir=$(SUBDIR), tag=$(IMAGE))"; \
-	  docker build $(if $(filter 1,$(PULL)),--pull) $(if $(filter 1,$(NC)),--no-cache) \
-	    --build-arg PORTABLE_BUILD=1 \
-	    --build-arg EOPF_GEOZARR_REF=$(REF) \
-	    --build-arg EOPF_GEOZARR_SUBDIR=$(SUBDIR) \
-	    -t $(IMAGE) -f $(DOCKERFILE) . ; \
+image-import:
+	# import image into k3d cluster
+	@if command -v k3d >/dev/null 2>&1; then \
+	  echo "Importing image into k3d cluster..."; \
+	  k3d image import --cluster k3s-default $(IMAGE) || true; \
 	else \
-	  echo "==> Building WHEEL image for $(PLATFORM) (ref=$(REF), subdir=$(SUBDIR), tag=$(IMAGE))"; \
-	  docker buildx build --platform=$(PLATFORM) \
-	    $(if $(filter 1,$(PULL)),--pull) $(if $(filter 1,$(NC)),--no-cache) \
-	    --build-arg PORTABLE_BUILD=0 \
-	    --build-arg EOPF_GEOZARR_REF=$(REF) \
-	    --build-arg EOPF_GEOZARR_SUBDIR=$(SUBDIR) \
-	    -t $(IMAGE) --load -f $(DOCKERFILE) . ; \
+	  true; \
 	fi
 
-push:
-	docker push $(IMAGE)
+ensure-pvc:
+	# create namespace + pvc if not exists
+	@bash scripts/ensure_pvc.sh $(NAMESPACE) $(PVC_NAME)
 
-.PHONY: load _check-image load-k3d load-minikube
+template: ensure-pvc
+	# apply workflowtemplate to cluster
+	@echo "Applying WorkflowTemplate..."
+	kubectl apply -n $(NAMESPACE) -f workflows/geozarr-convert-template.yaml
 
-_check-image:
-	@docker image inspect $(IMAGE) >/dev/null 2>&1 || \
-	  (echo "Image $(IMAGE) not found locally. Run: make build"; exit 2)
+apply: template
 
-load: _check-image
-	@set -euo pipefail; \
-	case "$(LOAD_STRATEGY)" in \
-	  k3d)       $(MAKE) load-k3d ;; \
-	  minikube)  $(MAKE) load-minikube ;; \
-	  push)      $(MAKE) push ;; \
-	  auto|"") \
-	    echo "==> Auto-detecting loader"; \
-	    if command -v k3d >/dev/null 2>&1 && k3d cluster list | awk 'NR>1{print $$1}' | grep -qx "$(CLUSTER)"; then \
-	      $(MAKE) load-k3d; \
-	    elif command -v minikube >/dev/null 2>&1 && minikube status >/dev/null 2>&1; then \
-	      $(MAKE) load-minikube; \
-	    else \
-	      echo "No local k3d/minikube cluster detected. Use: make push (or set LOAD_STRATEGY=push)."; \
-	      exit 2; \
-	    fi ;; \
-	  *) \
-	    echo "Unknown LOAD_STRATEGY='$(LOAD_STRATEGY)'"; \
-	    exit 2 ;; \
-	esac
+submit:
+	# submit workflow run with parameters
+	@[ -f params.json ] || { echo "params.json not found"; exit 2; }
+	@PARAMS=$$(python scripts/params_to_flags.py params.json); \
+	echo "argo submit -n $(NAMESPACE) --from workflowtemplate/geozarr-convert -p image=$(IMAGE) -p pvc_name=$(PVC_NAME) $$PARAMS"; \
+	argo submit -n $(NAMESPACE) --from workflowtemplate/geozarr-convert -p image=$(IMAGE) -p pvc_name=$(PVC_NAME) $$PARAMS
+	@$(MAKE) ui
 
-load-k3d: _check-image
-	@echo "==> Importing $(IMAGE) into k3d ($(CLUSTER))"
-	@k3d image import $(IMAGE) --cluster $(CLUSTER)
+pod:
+	@kubectl get pods -n $(NAMESPACE) -l workflows.argoproj.io/workflow -o jsonpath='{.items[0].metadata.name}'; echo
 
-load-minikube: _check-image
-	@echo "==> Loading $(IMAGE) into minikube"
-	minikube image load $(IMAGE)
+logs:
+	( argo logs -n $(NAMESPACE) @latest -c main -f || kubectl logs -n $(NAMESPACE) $$(make -s pod) -c main -f ) | sed -u 's/\r//g'
 
-# ===== Argo & template =====
+logs-pod:
+	kubectl logs -n $(NAMESPACE) $$(make -s pod) -c main -f | sed -u 's/\r//g'
+
+fetch:
+	@echo "Fetching /data from latest pod → ./out ..."
+	mkdir -p out
+	P=$$(make -s pod); \
+	kubectl cp $(NAMESPACE)/$$P:/data ./out || true
+
+status:
+	argo list -n $(NAMESPACE) --status
+
+env:
+	@echo IMAGE=$(IMAGE)
+	@echo NAMESPACE=$(NAMESPACE)
+	@echo PVC_NAME=$(PVC_NAME)
+	@echo PORTABLE_BUILD=$(PORTABLE_BUILD)
+	@echo BASE_IMAGE=$(BASE_IMAGE)
+	@echo RUNTIME_BASE_IMAGE=$(RUNTIME_BASE_IMAGE)
+	@echo EOPF_GEOZARR_REF=$(EOPF_GEOZARR_REF)
+	@echo EOPF_GEOZARR_SUBDIR=$(EOPF_GEOZARR_SUBDIR)
+	@echo DM_RAW_BASE=$(DM_RAW_BASE)
+
+down:
+	-argo delete -n $(NAMESPACE) --all || true
+	-kubectl delete -n $(NAMESPACE) workflowtemplate geozarr-convert || true
+	-kubectl delete -n $(NAMESPACE) pvc $(PVC_NAME) || true
+
+doctor:
+	@echo "Docker:    $$(docker --version 2>/dev/null || echo missing)"
+	@echo "kubectl:   $$(kubectl version --client=true --short 2>/dev/null || echo missing)"
+	@echo "argo:      $$(argo version --short 2>/dev/null || echo missing)"
+	@echo "k3d:       $$(k3d version 2>/dev/null || echo 'not installed (ok)')"
+	@echo "jq:        $$(jq --version 2>/dev/null || echo 'optional (we use Python)')"
+
+.PHONY: argo-install
 argo-install:
-	kubectl create ns $(NAMESPACE) 2>/dev/null || true
-	kubectl apply -n $(NAMESPACE) -f https://github.com/argoproj/argo-workflows/releases/download/v3.7.1/install.yaml
+	# install argo workflows CRDs + controller (pinned v3.6.5)
+	@echo "Installing Argo Workflows $(ARGO_VER) into namespace $(NAMESPACE)..."
+	@kubectl get namespace $(NAMESPACE) >/dev/null 2>&1 || kubectl create namespace $(NAMESPACE)
+	kubectl apply -n $(NAMESPACE) -f $(ARGO_INSTALL_URL)
+	@echo "Waiting for Argo controller and server to become ready..."
 	kubectl -n $(NAMESPACE) rollout status deploy/workflow-controller
 	kubectl -n $(NAMESPACE) rollout status deploy/argo-server
+	@echo "Verifying CRDs..."
+	kubectl api-resources | grep -q WorkflowTemplate && echo "CRDs present." || (echo "CRDs missing!"; exit 1)
+.PHONY: help
+help:
+	@echo ""
+	@echo "Targets:"
+	@echo "  bootstrap     Install Docker (where supported), k3d, kubectl, argo CLI."
+	@echo "  up            Install Argo v$(ARGO_VER), build, import image, ensure ns+PVC, apply template, submit."
+	@echo "  build         Build the container image ($(IMAGE))."
+	@echo "  image-import  Import the image into the k3d cluster."
+	@echo "  ensure-pvc    Ensure namespace and PVC exist (idempotent)."
+	@echo "  template      Apply WorkflowTemplate."
+	@echo "  submit        Submit a run from the WorkflowTemplate."
+	@echo "  logs          Tail logs for the latest workflow.
+	@echo "  get-output    Copy from /data in latest pod: OUTPUT_PATH, LOCAL_PATH"
+	@echo "  fetch         Copy REMOTE_PATH from PVC via helper pod to LOCAL_DIR""
+	@echo "  pod           Print the name of the latest pod."
+	@echo "  down          Delete Argo objects (namespace kept)"
+	@echo "  doctor        Print versions of tools."
+	@echo ""
+	@echo "Useful vars (override as needed):"
+	@echo "  NAMESPACE=argo PVC_NAME=geozarr-pvc IMAGE=eopf-geozarr:dev ARGO_VER=v3.6.5"
+	@echo ""
 
-template:
-	@mkdir -p $(WORKDIR)
-	@echo "==> Rendering $(TPL) with image $(IMAGE) and imagePullPolicy=$(PULLPOL)"
-	@sed -E \
-	  -e 's#^([[:space:]]*image:[[:space:]]*).*#\1$(IMAGE)#' \
-	  -e 's#^([[:space:]]*imagePullPolicy:[[:space:]]*).*#\1$(PULLPOL)#' \
-	  $(TPL) > $(WORKDIR)/tpl.rendered.yaml
-	kubectl -n $(NAMESPACE) apply -f $(WORKDIR)/tpl.rendered.yaml
-	kubectl -n $(NAMESPACE) get workflowtemplate geozarr-convert -o yaml | sed -n '1,40p'
+.PHONY: bootstrap
+bootstrap:
+	# install/check docker, k3d, kubectl, argo CLI
+	@scripts/bootstrap.sh
+.PHONY: cluster
+cluster:
+	# ensure k3d cluster exists (create if missing)
+	@echo "Ensuring k3d cluster $(CLUSTER) exists..."
+	@if ! k3d cluster list | awk 'NR>1 {print $$1}' | grep -qx "$(CLUSTER)"; then \
+		echo "Creating cluster $(CLUSTER)..."; \
+		k3d cluster create $(CLUSTER); \
+	else \
+		echo "Cluster $(CLUSTER) already exists."; \
+	fi
+.PHONY: get-output
+# Copy a result file/folder from the latest pod's /data to local path.
+# Usage: make get-output OUTPUT_PATH=/data/out.zarr LOCAL_PATH=./out.zarr
+get-output:
+	@[ -n "$(OUTPUT_PATH)" ] || (echo "Set OUTPUT_PATH=/data/..." && exit 1)
+	@[ -n "$(LOCAL_PATH)" ] || (echo "Set LOCAL_PATH=./..." && exit 1)
+	@POD=$$(make -s pod); \
+	  echo "Copying from $$POD:$(OUTPUT_PATH) -> $(LOCAL_PATH)"; \
+	  kubectl -n $(NAMESPACE) cp "$$POD:$(OUTPUT_PATH)" "$(LOCAL_PATH)"
 
-# ===== Convenience targets =====
-apply: build load argo-install template
-	@echo "==> apply done"
-
-dev: build load template
-	@echo "==> dev cycle complete"
-
-# ===== Submissions =====
-submit: _ensure-dirs
-	@STAC=$${STAC_URL:-$$(jq -r '.arguments.parameters[] | select(.name=="stac_url").value' $(PARAMS))}; \
-	OUT=$${OUTPUT_ZARR:-$$(jq -r '.arguments.parameters[] | select(.name=="output_zarr").value' $(PARAMS))}; \
-	JSON_GRP=$$(jq -r '.arguments.parameters[] | select(.name=="groups").value' $(PARAMS)); \
-	GRP="$(if $(strip $(ZARR_GROUPS)),$(value ZARR_GROUPS),$${JSON_GRP})"; \
-	echo "Submitting:"; echo "  stac_url=$$STAC"; echo "  output_zarr=$$OUT"; echo "  groups=$$GRP"; \
-	WF=$$(argo submit -n $(NAMESPACE) --from workflowtemplate/geozarr-convert \
-	  -p stac_url="$$STAC" -p output_zarr="$$OUT" -p groups="$$GRP" -o name); \
-	TSTAMP=$$(date +%Y%m%d-%H%M%S); \
-	argo get -n $(NAMESPACE) $$WF -o json > runs/$${TSTAMP}-$${WF##*/}.json; \
-	argo get -n $(NAMESPACE) $$WF --output wide | tee runs/$${TSTAMP}-$${WF##*/}.summary.txt; \
-	echo "Workflow: $$WF"
-
-submit-cli: _ensure-dirs
-	@JSON_GRP=$$(jq -r '.arguments.parameters[] | select(.name=="groups").value' $(PARAMS)); \
-	GRP="$(if $(strip $(ZARR_GROUPS)),$(value ZARR_GROUPS),$${JSON_GRP})"; \
-	WF=$$(argo submit -n $(NAMESPACE) --from workflowtemplate/geozarr-convert \
-	  -p stac_url="$$(jq -r '.arguments.parameters[] | select(.name=="stac_url").value' $(PARAMS))" \
-	  -p output_zarr="$$(jq -r '.arguments.parameters[] | select(.name=="output_zarr").value' $(PARAMS))" \
-	  -p groups="$$GRP" -o name); \
-	TSTAMP=$$(date +%Y%m%d-%H%M%S); \
-	argo get -n $(NAMESPACE) $$WF -o json > runs/$${TSTAMP}-$${WF##*/}.json; \
-	argo get -n $(NAMESPACE) $$WF --output wide | tee runs/$${TSTAMP}-$${WF##*/}.summary.txt; \
-	echo "Workflow: $$WF"
-
-submit-api: _ensure-dirs
-	kubectl -n $(NAMESPACE) port-forward svc/argo-server 2746:2746 >/dev/null 2>&1 & echo $$! > .pf.pid
-	sleep 1
-	curl -s -H 'Content-Type: application/json' \
-	  --data-binary @$(PARAMS) \
-	  http://localhost:2746/api/v1/workflows/$(NAMESPACE)/submit \
-	  | tee runs/submit-response.json | jq . >/dev/null || \
-	  (echo "Non-JSON response (see runs/submit-response.json)"; exit 1)
-	-@[ -f .pf.pid ] && kill $$(cat .pf.pid) 2>/dev/null || true
-	-@rm -f .pf.pid
-
-# ===== Inspect & housekeeping =====
-status:
-	argo list -n $(NAMESPACE); echo; kubectl -n $(NAMESPACE) get wf
-
-latest:
-	argo get -n $(NAMESPACE) @latest --output wide
-
-logs-save: _ensure-dirs
-	@WF=$$(argo list -n $(NAMESPACE) --output name | tail -1); \
-	TSTAMP=$$(date +%Y%m%d-%H%M%S); \
-	argo logs -n $(NAMESPACE) $$WF -c main > logs/$${TSTAMP}-$${WF##*/}.log; \
-	echo "Wrote logs/$${TSTAMP}-$${WF##*/}.log"
-
-clean:
-	argo delete -n $(NAMESPACE) --all || true
-	kubectl -n $(NAMESPACE) delete pod -l workflows.argoproj.io/completed=true --force --grace-period=0 || true
-
-_ensure-dirs:
-	@mkdir -p runs logs $(WORKDIR)
-
-fetch-tar: _ensure-dirs
-	@WF=$$(argo list -n $(NAMESPACE) --output name | tail -1 | sed 's#.*/##'); \
-	PVC="$$WF-outpvc"; OUTDIR="runs/$$WF"; \
-	echo "Workflow: $$WF"; echo "PVC: $$PVC"; mkdir -p $$OUTDIR; \
-	kubectl -n $(NAMESPACE) delete pod fetch-$$WF --ignore-not-found >/dev/null 2>&1 || true; \
-	kubectl -n $(NAMESPACE) apply -f - <<-YAML ; \
-		apiVersion: v1 \
-		kind: Pod \
-		metadata: \
-		  name: fetch-$$WF \
-		spec: \
-		  restartPolicy: Never \
-		  containers: \
-		  - name: fetch \
-		    image: busybox:1.36 \
-		    command: ["sh","-lc","sleep 600"] \
-		    volumeMounts: \
-		    - name: out \
-		      mountPath: /mnt/out \
-		  volumes: \
-		  - name: out \
-		    persistentVolumeClaim: \
-		      claimName: $$PVC \
-	YAML
-	kubectl -n $(NAMESPACE) wait --for=condition=Ready pod/fetch-$$WF --timeout=60s
-	kubectl -n $(NAMESPACE) cp fetch-$$WF:/mnt/out/geozarr.tar.gz $$OUTDIR/geozarr.tar.gz
-	tar -xzf $$OUTDIR/geozarr.tar.gz -C $$OUTDIR
-	kubectl -n $(NAMESPACE) cp fetch-$$WF:/mnt/out/. $$OUTDIR/ || true
-	kubectl -n $(NAMESPACE) delete pod fetch-$$WF --wait=false
-	@echo "Unpacked into $$OUTDIR/"
-
-run: apply submit fetch-tar
-
-clean-pvc:
-	kubectl -n $(NAMESPACE) delete pvc -l workflows.argoproj.io/workflow 2>/dev/null || true
+.PHONY: ui
+ui:
+	@(argo -n $(NAMESPACE) logs @latest -c main -f || argo -n $(NAMESPACE) logs @latest -f) | python3 scripts/progress_ui.py

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,12 @@ CACHE_BUST := $(shell date +%s)
 CLUSTER ?= k3s-default
 REMOTE_PATH ?= /data
 LOCAL_DIR ?= ./out
+PYTHON ?= python3
+PARAMS_FILE ?= params.json
+ARGO_PROXY_PORT ?= 8081
+K8S_PROXY_PORT ?= 8001
 
-.PHONY: up up-fast up-rebuild build rebuild image-import ensure-pvc template apply submit logs logs-pod pod fetch status down env doctor
+.PHONY: up up-fast up-rebuild build rebuild image-import ensure-pvc template apply submit logs logs-pod pod fetch status down env doctor validate
 
 up: bootstrap cluster argo-install build image-import ensure-pvc template submit
 	# full local run: bootstrap → cluster → argo → build → import → pvc → template → submit
@@ -50,7 +54,7 @@ image-import:
 	# import image into k3d cluster
 	@if command -v k3d >/dev/null 2>&1; then \
 	  echo "Importing image into k3d cluster..."; \
-	  k3d image import --cluster k3s-default $(IMAGE) || true; \
+	  k3d image import --cluster $(CLUSTER) $(IMAGE) || true; \
 	else \
 	  true; \
 	fi
@@ -68,8 +72,9 @@ apply: template
 
 submit:
 	# submit workflow run with parameters
-	@[ -f params.json ] || { echo "params.json not found"; exit 2; }
-	@PARAMS=$$(python scripts/params_to_flags.py params.json); \
+	@[ -f $(PARAMS_FILE) ] || { echo "$(PARAMS_FILE) not found"; exit 2; }
+	@$(MAKE) validate >/dev/null || true; \
+	PARAMS=$$($(PYTHON) scripts/params_to_flags.py $(PARAMS_FILE)); \
 	echo "argo submit -n $(NAMESPACE) --from workflowtemplate/geozarr-convert -p image=$(IMAGE) -p pvc_name=$(PVC_NAME) $$PARAMS"; \
 	argo submit -n $(NAMESPACE) --from workflowtemplate/geozarr-convert -p image=$(IMAGE) -p pvc_name=$(PVC_NAME) $$PARAMS
 	@$(MAKE) ui
@@ -84,13 +89,24 @@ logs-pod:
 	kubectl logs -n $(NAMESPACE) $$(make -s pod) -c main -f | sed -u 's/\r//g'
 
 fetch:
-	@echo "Fetching /data from latest pod → ./out ..."
-	mkdir -p out
+	@echo "Fetching $(REMOTE_PATH) from latest pod → $(LOCAL_DIR) ..."
+	mkdir -p $(LOCAL_DIR)
 	P=$$(make -s pod); \
-	kubectl cp $(NAMESPACE)/$$P:/data ./out || true
+	kubectl cp $(NAMESPACE)/$$P:$(REMOTE_PATH) $(LOCAL_DIR) || \
+	  bash scripts/fetch_from_pvc.sh $(NAMESPACE) $(PVC_NAME) $(REMOTE_PATH) $(LOCAL_DIR)
+
+.PHONY: fetch-pvc
+fetch-pvc:
+	@echo "Fetching from PVC $(PVC_NAME) → $(LOCAL_DIR) ..."
+	mkdir -p $(LOCAL_DIR)
+	bash scripts/fetch_from_pvc.sh $(NAMESPACE) $(PVC_NAME) $(REMOTE_PATH) $(LOCAL_DIR)
 
 status:
-	argo list -n $(NAMESPACE) --status
+	@if [ -n "$(STATUS)" ]; then \
+	  argo list -n $(NAMESPACE) --status $(STATUS); \
+	else \
+	  argo list -n $(NAMESPACE); \
+	fi
 
 env:
 	@echo IMAGE=$(IMAGE)
@@ -126,42 +142,88 @@ argo-install:
 	kubectl -n $(NAMESPACE) rollout status deploy/argo-server
 	@echo "Verifying CRDs..."
 	kubectl api-resources | grep -q WorkflowTemplate && echo "CRDs present." || (echo "CRDs missing!"; exit 1)
+	@echo "Ensuring local UI dev ServiceAccount bound to admin (optional)..."
+	@bash scripts/ensure_ui_access.sh $(NAMESPACE) || true
 .PHONY: help
 help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  bootstrap     Install Docker (where supported), k3d, kubectl, argo CLI."
 	@echo "  up            Install Argo v$(ARGO_VER), build, import image, ensure ns+PVC, apply template, submit."
+	@echo "                Tip: Ensure Docker Desktop is running before 'make up'."
 	@echo "  build         Build the container image ($(IMAGE))."
 	@echo "  image-import  Import the image into the k3d cluster."
 	@echo "  ensure-pvc    Ensure namespace and PVC exist (idempotent)."
 	@echo "  template      Apply WorkflowTemplate."
 	@echo "  submit        Submit a run from the WorkflowTemplate."
-	@echo "  logs          Tail logs for the latest workflow.
+	@echo "  logs          Tail logs for the latest workflow."
 	@echo "  get-output    Copy from /data in latest pod: OUTPUT_PATH, LOCAL_PATH"
-	@echo "  fetch         Copy REMOTE_PATH from PVC via helper pod to LOCAL_DIR""
+	@echo "  fetch         Copy REMOTE_PATH from PVC via helper pod to LOCAL_DIR"
 	@echo "  pod           Print the name of the latest pod."
 	@echo "  down          Delete Argo objects (namespace kept)"
 	@echo "  doctor        Print versions of tools."
 	@echo ""
+	@echo "UI shortcuts:"
+	@echo "  ui            Show progress + print UI links (port-forward)"
+	@echo "  ui-forward    Port-forward argo-server to localhost:2746"
+	@echo "  ui-open       Open UI with a short-lived token (client mode)"
+	@echo "  ui-mode-server  Run UI without login (dev only)"
+	@echo "  ui-mode-client  Default token-based mode"
+	@echo "  ui-pf-stop      Stop background port-forward"
+	@echo "  ui-k8s-proxy    (Optional) Start kubectl API proxy; then use the printed link"
+	@echo ""
 	@echo "Useful vars (override as needed):"
 	@echo "  NAMESPACE=argo PVC_NAME=geozarr-pvc IMAGE=eopf-geozarr:dev ARGO_VER=v3.6.5"
 	@echo ""
+	@echo "Maintenance:"
+	@echo "  cluster-delete Delete the k3d cluster if it exists (use after partial/failed creates)."
 
-.PHONY: bootstrap
+.PHONY: docker-wait bootstrap
+docker-wait:
+	# Wait for Docker daemon to be ready (macOS Docker Desktop can take a while)
+	@SECS=$${DOCKER_WAIT_SECS:-120}; \
+	for i in $$(seq 1 $$SECS); do \
+	  if docker version >/dev/null 2>&1; then \
+	    echo "Docker is ready."; \
+	    exit 0; \
+	  fi; \
+	  if [ $$i -eq $$SECS ]; then \
+	    echo "Docker is not ready after $$SECS seconds."; \
+	    echo "Tip: On macOS, open Docker Desktop and wait until it shows \"Running\"."; \
+	    exit 1; \
+	  fi; \
+	  sleep 1; \
+	done
+
 bootstrap:
 	# install/check docker, k3d, kubectl, argo CLI
 	@scripts/bootstrap.sh
 .PHONY: cluster
-cluster:
+cluster: docker-wait
 	# ensure k3d cluster exists (create if missing)
 	@echo "Ensuring k3d cluster $(CLUSTER) exists..."
 	@if ! k3d cluster list | awk 'NR>1 {print $$1}' | grep -qx "$(CLUSTER)"; then \
 		echo "Creating cluster $(CLUSTER)..."; \
-		k3d cluster create $(CLUSTER); \
+		if ! k3d cluster create $(CLUSTER); then \
+		  echo "\nERROR: Failed to create k3d cluster. This is often caused by a Docker Engine issue (e.g. Internal Server Error 500)."; \
+		  echo "Troubleshooting steps:"; \
+		  echo "  1) Ensure Docker Desktop is running and healthy (Docker Desktop -> Running)."; \
+		  echo "  2) In a terminal, run: docker version && docker ps"; \
+		  echo "  3) If errors persist, Restart Docker Desktop (Docker Desktop -> Quit, then reopen)."; \
+		  echo "  4) If a partial cluster exists, try: make cluster-delete and re-run make up."; \
+		  exit 2; \
+		fi; \
 	else \
 		echo "Cluster $(CLUSTER) already exists."; \
 	fi
+
+.PHONY: cluster-delete
+cluster-delete: docker-wait
+	# delete the k3d cluster if it exists (useful after partial/failed creates)
+	@echo "Deleting k3d cluster $(CLUSTER) if it exists..."
+	@k3d cluster list | awk 'NR>1 {print $$1}' | grep -qx "$(CLUSTER)" \
+	  && k3d cluster delete $(CLUSTER) \
+	  || echo "No existing cluster named $(CLUSTER)."
 .PHONY: get-output
 # Copy a result file/folder from the latest pod's /data to local path.
 # Usage: make get-output OUTPUT_PATH=/data/out.zarr LOCAL_PATH=./out.zarr
@@ -174,4 +236,80 @@ get-output:
 
 .PHONY: ui
 ui:
-	@(argo -n $(NAMESPACE) logs @latest -c main -f || argo -n $(NAMESPACE) logs @latest -f) | python3 scripts/progress_ui.py
+	@(argo -n $(NAMESPACE) logs @latest -c main -f || argo -n $(NAMESPACE) logs @latest -f) | $(PYTHON) scripts/progress_ui.py
+
+.PHONY: ui-forward
+ui-forward:
+	@echo "Port-forwarding argo-server to localhost:2746 (CTRL+C to stop)..."
+	kubectl -n $(NAMESPACE) port-forward svc/argo-server 2746:2746
+
+.PHONY: ui-open
+ui-open:
+	@TOKEN=$$(kubectl -n $(NAMESPACE) create token argo-ui-dev --duration=1h 2>/dev/null || kubectl -n $(NAMESPACE) create token argo-server --duration=1h 2>/dev/null || true); \
+	URL=https://127.0.0.1:2746; \
+	if [ -n "$$TOKEN" ]; then \
+	  echo "Opening $$URL with token..."; \
+	  open "$$URL/auth/token?token=$$TOKEN" || true; \
+	  echo "If the page doesn't auto-auth, paste the token from below:"; \
+	  echo $$TOKEN; \
+	  echo "Alt link forms:"; \
+	  echo "  $$URL/?token=$$TOKEN"; \
+	  echo "  $$URL/#/?token=$$TOKEN"; \
+	else \
+	  echo "Open $$URL in your browser. If prompted, mint a token with:"; \
+	  echo "  kubectl -n $(NAMESPACE) create token argo-server"; \
+	fi
+
+.PHONY: ui-pf-stop
+ui-pf-stop:
+	@if [ -f .work/argo_pf.pid ]; then \
+	  PID=$$(cat .work/argo_pf.pid); \
+	  echo "Stopping background port-forward (pid $$PID)..."; \
+	  kill $$PID || true; \
+	  rm -f .work/argo_pf.pid .work/argo_pf.port; \
+	else \
+	  echo "No background port-forward pidfile found."; \
+	fi
+
+.PHONY: ui-mode-server
+ui-mode-server:
+	@echo "Switching argo-server auth mode to 'server' (no-login local dashboard)..."
+	@ARGO_SET_SECURE=false $(PYTHON) scripts/argo_set_auth_mode.py --namespace $(NAMESPACE) --mode server
+	kubectl -n $(NAMESPACE) rollout status deploy/argo-server
+	@echo "Done. Use 'make ui-forward' then open http://127.0.0.1:2746 (no token required)."
+
+.PHONY: ui-mode-client
+ui-mode-client:
+	@echo "Switching argo-server auth mode to 'client' (default token-based)..."
+	@$(PYTHON) scripts/argo_set_auth_mode.py --namespace $(NAMESPACE) --mode client
+	kubectl -n $(NAMESPACE) rollout status deploy/argo-server
+	@echo "Done. Use 'make ui-open' to login with a token."
+
+.PHONY: ui-k8s-proxy
+ui-k8s-proxy:
+	@echo "Starting kubectl API server proxy (CTRL+C to stop)..."
+	@kubectl proxy --port=$(K8S_PROXY_PORT)
+
+.PHONY: ui-k8s-proxy-bg
+ui-k8s-proxy-bg:
+	@mkdir -p .work
+	@echo "Starting kubectl API server proxy in background on http://127.0.0.1:$(K8S_PROXY_PORT) ..."
+	@echo "$(K8S_PROXY_PORT)" > .work/kubectl_proxy.port
+	@nohup kubectl proxy --port=$(K8S_PROXY_PORT) >/dev/null 2>&1 & echo $$! > .work/kubectl_proxy.pid
+	@echo "Argo UI via API proxy (if needed): http://127.0.0.1:$(K8S_PROXY_PORT)/api/v1/namespaces/$(NAMESPACE)/services/https:argo-server:web/proxy/"
+
+.PHONY: ui-k8s-proxy-stop
+ui-k8s-proxy-stop:
+	@if [ -f .work/kubectl_proxy.pid ]; then \
+	  PID=$$(cat .work/kubectl_proxy.pid); \
+	  echo "Stopping kubectl proxy (pid $$PID)..."; \
+	  kill $$PID || true; \
+	  rm -f .work/kubectl_proxy.pid .work/kubectl_proxy.port; \
+	else \
+	  echo "No kubectl proxy pidfile found."; \
+	fi
+
+
+.PHONY: validate
+validate:
+	@$(PYTHON) scripts/validate_groups.py $(PARAMS_FILE) || true

--- a/README.md
+++ b/README.md
@@ -1,215 +1,110 @@
-# data-model-pipeline
+# Data Model Pipeline → GeoZarr (Argo prototype)
 
-Argo-native workflow for converting **STAC Zarr** items to **GeoZarr**, using the `eopf-geozarr` converter from the [data-model](https://github.com/EOPF-Explorer/data-model) repo.
-
-This repository provides the **orchestration layer** (Docker image + Argo WorkflowTemplate + Make targets). The **converter implementation** and **dependency lock** live in `data-model`. At build time, we fetch `pyproject.toml` and `uv.lock` from `data-model@REF`, install those third-party dependencies exactly, then install `eopf-geozarr` from the same ref **without re-resolving**. This keeps runtime behavior reproducible while allowing this repo to evolve independently as the pipeline runner.
-
----
-
-## High-level overview
-
-### What this does
-- **Builds a runner image** that contains a _locked_ geospatial Python stack (from `data-model@REF`) plus the `eopf-geozarr` CLI.
-- **Applies an Argo WorkflowTemplate** that:
-  - Preflights the STAC Zarr URL (best-effort HTTP HEAD).
-  - Normalizes/validates **group paths** using xarray (prints a small tree of available groups).
-  - Runs the conversion: `eopf-geozarr convert …` with optional Dask performance report.
-  - Packages outputs into a tarball on a per-run **PVC** for retrieval.
-- **Convenience Make targets** to build, load/push, install Argo, submit runs, and fetch artifacts.
-
-### Why a separate repo?
-- **Separation of concerns**: `data-model` provides the GeoZarr data model and converter; this repo provides orchestration and infra glue.
-- **Reproducible builds**: we consume `data-model`’s **`uv.lock`** directly to freeze third-party deps, then install `eopf-geozarr` _without_ dependency resolution.
-- **Safe iteration**: change the workflow, image, or cluster tooling without touching the converter library.
-
-### Architecture (conceptual)
-```mermaid
-flowchart LR
-  DEV["Dev machine (make build)"] --> IMG["Runner image"]
-  IMG -->|load/push| K8S[(Kubernetes cluster)]
-  subgraph Argo
-    TPL["WorkflowTemplate: geozarr-convert"]
-    WF["Workflow run (PVC artifacts)"]
-  end
-  K8S --> Argo
-  TPL --> WF
-  WF -->|reads| STAC["STAC Zarr URL"]
-  WF -->|writes| PVC["PVC: /outputs"]
-  PVC --> TAR["geozarr.tar.gz + dask-report.html"]
-  TAR --> FETCH["make fetch-tar (runs/{wf}/)"]
-```
+Convert Sentinel Zarr (from STAC) into **[GeoZarr](https://geozarr.readthedocs.io/)** using **Argo Workflows**.
+This repo is a **local prototype**: it demonstrates the EOPF conversion flow end‑to‑end on a lightweight **k3d** cluster.
 
 ---
 
 ## Quickstart
 
-### One-shot apply
 ```bash
-make apply PORTABLE=1   # build + load + argo-install + template
-```
+# full local run (bootstrap → cluster → argo → build → import → pvc → template → submit)
+make up
 
-### Faster dev loop
-```bash
-make dev   # build + load + template (skip argo install)
-```
+# if your cluster is already up (fast path):
+make up-fast
 
-
-```bash
-# 0) Build the image (uses data-model@<ref> lockfile, then installs eopf-geozarr with --no-deps)
-make build REF=<commit-sha-or-tag> TAG=dev
-# TIP (arm64 or wheel gaps): add PORTABLE=1
-
-# 1) Load into your k3d dev cluster and install Argo
-make load-k3d
-make argo-install
-
-# 2) Apply the WorkflowTemplate and submit a run
-make template
-make submit   STAC_URL="https://…/S2B_MSIL2A_20250518…zarr"   OUTPUT_ZARR="./S2B_MSIL2A_20250518_T29RLL_geozarr.zarr"   GROUPS="measurements/reflectance/r20m"
-
-# 3) Fetch artifacts (tarball + optional dask-report.html) from the PVC
-make fetch-tar
-```
-Artifacts land under `runs/<workflow-name>/`.
-
----
-
-## Repository layout
-
-- `docker/Dockerfile` — builds the runner image.
-  - Downloads `pyproject.toml` + `uv.lock` from `data-model@REF` (optionally a subdir).
-  - `uv export` → exact requirements; installs **third-party deps** first.
-  - Installs `eopf-geozarr` from the same ref **with `--no-deps`**.
-- `workflows/geozarr-convert-template.yaml`
-  - Preflight (HEAD) the STAC URL (best-effort; non-fatal).
-  - Normalize/echo groups; validate with xarray (prints tree; fails early with suggestions).
-  - Run `eopf-geozarr convert …`. The template now uses POSIX-safe `echo` for command tracing (instead of `printf %q`).
-  - Tar the GeoZarr into `/outputs/geozarr.tar.gz`; expose artifacts from PVC.
-- `Makefile` — build → load/push → argo install → template → submit → fetch → clean.
-
----
-
-## Build options
-
-- By default builds now use **stable tags** (`IMMUTABLE=0`) and **cached layers** (`NC=0`, `PULL=0`).
-- To force an immutable timestamp tag:
-  ```bash
-  make build IMMUTABLE=1
-  ```
-
-### Variants
-
-```bash
-# Default (wheel-first): fast, small image
-make build REF=main TAG=dev
-
-# Portable build (adds system GDAL/PROJ toolchain; robust if wheels are missing on your arch)
-make build REF=main TAG=dev PORTABLE=1
-
-# If eopf-geozarr lives in a subdir in data-model, pass SUBDIR (must end with '/')
-make build REF=main SUBDIR=tools/eopf-geozarr/ TAG=dev
-```
-
-- Image defaults to `ghcr.io/eopf-explorer/data-model-pipeline:<TAG>`.
-- If you don’t push, keep `imagePullPolicy: IfNotPresent` in the template and run `make load-k3d`.
-
----
-
-## Workflow parameters
-
-From `workflows/geozarr-convert-template.yaml`:
-
-| Parameter         | Type    | Description                                                                                  | Example(s) |
-|-------------------|---------|----------------------------------------------------------------------------------------------|------------|
-| `stac_url`        | string  | STAC Zarr URL to convert                                                                     | `https://…/S2B_MSIL2A_…zarr` |
-| `output_zarr`     | string  | Output path (container FS)                                                                   | `./S2B_MSIL2A_…_geozarr.zarr` |
-| `groups`          | string  | **Space-separated** group paths. Leading `/` optional; template normalizes.                  | `measurements/reflectance/r20m /measurements/reflectance/r10m` |
-| `dask_perf_html`  | string  | Path to write Dask performance report (optional)                                             | `out/debug/dask-report.html` |
-
-Override via env on submit:
-```bash
-make submit   STAC_URL="https://…"   OUTPUT_ZARR="./S2B_MSIL2A_…_geozarr.zarr"   GROUPS="/measurements/reflectance/r20m /measurements/reflectance/r10m"
+# follow logs
+make logs
 ```
 
 ---
 
-## Typical workflows
+## Prerequisites
 
-### Local dev with k3d
+- **Docker** (or compatible runtime)
+- **k3d** (k3s in Docker): https://k3d.io/
+- **kubectl**: https://kubernetes.io/docs/tasks/tools/
+- **Argo Workflows CLI**: https://argo-workflows.readthedocs.io/en/stable/cli/
+- **make**
+
+You can quickly verify tool versions:
+
 ```bash
-make build REF=<ref> TAG=dev
-make load-k3d
-make argo-install
-make template
-make submit
-make fetch-tar
-```
-
-### Pushing to GHCR (any cluster)
-```bash
-echo $GHCR_TOKEN | docker login ghcr.io -u <user> --password-stdin
-docker push ghcr.io/eopf-explorer/data-model-pipeline:dev
-
-# Ensure the cluster can pull from GHCR (public image or imagePullSecret)
-make argo-install
-make template
-make submit
-make fetch-tar
+make doctor
 ```
 
 ---
 
-## How the conversion step works
+## How it works
 
-1. **Validation** with xarray: opens the STAC, prints a group tree; errors list missing groups and suggested candidates under `/measurements`.
-2. **Execution** uses `eopf-geozarr convert` with `--dask-cluster` enabled and optional `--dask-perf-html`.
-3. **Packaging** copies the Dask HTML (if produced), and tars the GeoZarr output dir for a single-file artifact.
-4. **Artifacts** are exposed from the per-run PVC and retrievable via `make fetch-tar`.
-
----
-
-## Troubleshooting
-
-- **ImagePullBackOff**: If using a local tag, run `make load-k3d`. Keep `imagePullPolicy: IfNotPresent`.
-- **`rasterio`/GDAL import errors**: rebuild with `PORTABLE=1` and re-apply the template.
-- **STAC URL preflight fails**: the HEAD is best-effort; the actual open happens during conversion and will surface real errors.
-- **Group not found**: review the printed tree; use normalized absolute paths like `/measurements/reflectance/r20m`.
-- **No artifacts after run**: check workflow status (`argo get -n argo @latest --output wide`). Then `make fetch-tar` to pull into `runs/<WF>/`.
+The pipeline wraps the `eopf-geozarr` CLI and runs it in a container via an Argo **WorkflowTemplate**.
+Key files:
+- `docker/Dockerfile` – builds a runnable image with `eopf-geozarr`.
+- `workflows/geozarr-convert-template.yaml` – WorkflowTemplate used for submissions.
+- `scripts/convert.sh` – robust wrapper: parses flags, normalizes group paths, preflights `.zgroup`, and validates groups (optional).
+- `params.json` – default parameter values for local runs.
+- `Makefile` – repeatable developer flow (cluster, install argo, build image, submit, logs, fetch results).
 
 ---
 
-## Clean up
+## Usage
+
+### 1) Configure parameters (optional)
+
+Edit `params.json` if you want to override defaults:
+
+```json
+{
+  "arguments": {
+    "parameters": [
+      {"name": "stac_url",       "value": "https://…/S2…/my-scene.zarr"},
+      {"name": "output_zarr",    "value": "/data/S2_scene_geozarr.zarr"},
+      {"name": "groups",         "value": "measurements/reflectance/r20m"},
+      {"name": "validate_groups","value": "false"}
+    ]
+  }
+}
+```
+
+Notes:
+- `output_zarr` must live under the mounted PVC path (`/data`).
+- `groups` accepts one or many group paths; the wrapper can also read `$GROUPS`/`$ARGO_GROUPS`.
+- If `validate_groups=true`, the run fails if a requested group is missing; otherwise a best‑effort suffix match is attempted with warnings.
+
+### 2) Run
 
 ```bash
-# Remove workflows and completed pods
-make clean
+make up          # first time (cluster + argo + build + submit)
+make up-fast     # subsequent runs (build + import + submit)
+make logs        # follow the most recent workflow logs
+```
 
-# Remove per-run PVCs (deletes artifacts)
-make clean-pvc
+### 3) Retrieve results
+
+```bash
+make fetch     # copies /data from the latest pod into ./out
 ```
 
 ---
 
-## Reproducibility & versioning
+## Limitations (prototype)
 
-- The runner image installs third-party dependencies from `data-model@REF`’s **`pyproject.toml` + `uv.lock`**, then installs `eopf-geozarr` from the same ref **with `--no-deps`**.  
-- To reproduce/upgrade the stack, bump `REF` (or a specific commit SHA) and rebuild:
-  ```bash
-  make build REF=<new-sha> TAG=dev
-  ```
+- Focused on **Sentinel Zarr → GeoZarr** single‑scene conversion.
+- Tested locally on **k3d**; not production‑hardened for multi‑node clusters.
+- Image is imported into the local cluster (no registry push).
+- Minimal validation beyond group presence/shape checks.
 
 ---
 
-## Roadmap (suggested)
+## Design docs
 
-- Publish CI workflow that builds `:sha` and `:main` images on push.
-- Add a sample STAC catalog and golden-test to smoke the template offline.
-- Publish a Helm chart wrapping the WorkflowTemplate + RBAC + imagePullSecrets.
-- Parameterize Dask cluster settings (threads/memory) in the template.
-- (If needed) toggle a “no-tar” mode to emit a directory tree directly to PVC.
+- **[Design brief](docs/DESIGN_BRIEF.md)** — constraints and non‑negotiables for the working prototype.
+- **[Explainer](docs/DESIGN_EXPLAINER.md)** — deeper rationale and operational guidance.
+- **GeoZarr**: [spec repository](https://github.com/zarr-developers/geozarr-spec), [docs](https://geozarr.readthedocs.io/).
 
 ---
 
 ## License
 
-See `LICENSE` in this repository.
+Licensed under the **Apache License, Version 2.0**. See [LICENSE](LICENSE).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,32 +4,64 @@ ARG RUNTIME_BASE_IMAGE=python:3.11-slim
 
 # ========= stage: builder =========
 FROM ${BASE_IMAGE} AS builder
-ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
-ARG PORTABLE_BUILD=0
-ARG EOPF_GEOZARR_REF=main
-ARG EOPF_GEOZARR_SUBDIR=
-ARG DM_RAW_BASE=https://raw.githubusercontent.com/EOPF-Explorer/data-model
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    GDAL_CONFIG=/usr/bin/gdal-config
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       ca-certificates curl git && rm -rf /var/lib/apt/lists/*
+# Build-time knobs
+ARG PORTABLE_BUILD=0
+# Git ref of the eopf-geozarr source (branch, tag, or commit)
+ARG EOPF_GEOZARR_REF=main
+# Optional subdirectory within the repo (empty means repo root)
+ARG EOPF_GEOZARR_SUBDIR=
+# Repo URL for the data-model project containing eopf-geozarr
+ARG EOPF_GEOZARR_REPO_URL=https://github.com/EOPF-Explorer/data-model.git
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git; \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Optional toolchain + GDAL/PROJ for sdists (needed in portable mode or fallback)
-ENV GDAL_CONFIG=/usr/bin/gdal-config
+# Optional toolchain + GDAL/PROJ for source builds (portable mode)
+RUN set -eux; \
+    if [ "$PORTABLE_BUILD" = "1" ]; then \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    gdal-bin libgdal-dev \
+    proj-bin libproj-dev; \
+    rm -rf /var/lib/apt/lists/*; \
+    fi
 
-# Pull lockfiles from data-model@<ref> (optionally a subdir)
-RUN set -eux;     mkdir -p /tmp/dm;     curl -fsSL -o /tmp/dm/pyproject.toml "${DM_RAW_BASE}/${EOPF_GEOZARR_REF}/${EOPF_GEOZARR_SUBDIR}pyproject.toml";     curl -fsSL -o /tmp/dm/uv.lock        "${DM_RAW_BASE}/${EOPF_GEOZARR_REF}/${EOPF_GEOZARR_SUBDIR}uv.lock";     test -s /tmp/dm/pyproject.toml && test -s /tmp/dm/uv.lock
+# Install uv and the GeoZarr converter from GitHub (not on PyPI)
+RUN set -eux; \
+    pip install -U pip uv; \
+    echo "Cloning ${EOPF_GEOZARR_REPO_URL} @ ${EOPF_GEOZARR_REF} ..."; \
+    git clone --depth 1 --branch "${EOPF_GEOZARR_REF}" "${EOPF_GEOZARR_REPO_URL}" /tmp/data-model; \
+    cd /tmp/data-model; \
+    if [ -n "${EOPF_GEOZARR_SUBDIR}" ]; then cd "${EOPF_GEOZARR_SUBDIR}"; fi; \
+    if uv pip install --system .; then \
+    echo "Installed eopf-geozarr successfully (no native build needed)."; \
+    else \
+    echo "Initial install failed, installing build toolchain + GDAL/PROJ and retrying..."; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    pkg-config \
+    gdal-bin libgdal-dev \
+    proj-bin libproj-dev; \
+    rm -rf /var/lib/apt/lists/*; \
+    uv pip install --system .; \
+    fi; \
+    cd /; rm -rf /tmp/data-model
 
-# uv + export pinned third-party requirements (exclude eopf-geozarr itself)
-RUN pip install -U pip uv && uv --version
-RUN set -euo pipefail;     cd /tmp/dm;     uv export --locked --format=requirements-txt --no-hashes -o /tmp/req.raw.txt;     awk 'BEGIN{IGNORECASE=1}       /^-e[[:space:]]/ || /^--editable[[:space:]]/ {next}       /@ file:/ || /file:\/\// {next}       /^eopf-geozarr([[:space:]]|==|$)/ {next}       /^[[:space:]]*#/ || /^[[:space:]]*$/ {next}       {print}' /tmp/req.raw.txt > /tmp/requirements.txt
-
-# Install third-party deps with resilient strategy
-RUN set -eux;   if [ "$PORTABLE_BUILD" = "1" ]; then     echo "PORTABLE_BUILD=1: installing build deps + GDAL/PROJ first";     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       build-essential pkg-config       gdal-bin libgdal-dev       proj-bin libproj-dev     && rm -rf /var/lib/apt/lists/*;     export GDAL_CONFIG=/usr/bin/gdal-config;     uv pip install --system --requirements /tmp/requirements.txt;   else     echo "Fast path: wheels-only, with automatic fallback to sdists if needed";     if env PIP_ONLY_BINARY=":all:" uv pip install --system --requirements /tmp/requirements.txt; then       echo "Wheels-only install succeeded.";     else       echo "Wheels-only failed; installing build deps + GDAL/PROJ and retrying from sdist...";       apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         build-essential pkg-config         gdal-bin libgdal-dev         proj-bin libproj-dev       && rm -rf /var/lib/apt/lists/*;       export GDAL_CONFIG=/usr/bin/gdal-config;       uv pip install --system --requirements /tmp/requirements.txt;     fi;   fi
-
-# Install eopf-geozarr itself (follow the data-model repo @ref/subdir)
-RUN set -eux;     if [ -n "$EOPF_GEOZARR_SUBDIR" ]; then       PKG_URL="eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model@${EOPF_GEOZARR_REF}#subdirectory=${EOPF_GEOZARR_SUBDIR%/}";     else       PKG_URL="eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model@${EOPF_GEOZARR_REF}";     fi;     uv pip install --system --no-deps "$PKG_URL"
-
+# Precompile stdlib/site-packages (best-effort)
 RUN python -m compileall -q /usr/local/lib/python3.11/site-packages || true
 
 # ========= stage: runtime =========
@@ -37,9 +69,21 @@ FROM ${RUNTIME_BASE_IMAGE} AS runtime
 ARG CACHE_BUST=0
 LABEL cache.bust="${CACHE_BUST}"
 ENV PYTHONUNBUFFERED=1
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       libstdc++6 libgomp1 libexpat1       gdal-bin proj-bin curl     && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libstdc++6 \
+    libgomp1 \
+    libexpat1 \
+    gdal-bin \
+    proj-bin \
+    curl; \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY --from=builder /usr/local /usr/local
 COPY scripts/ /app/scripts/
-RUN chmod -R a+rX /app && find /app/scripts -type f -name "*.sh" -exec chmod +x {} \; 
+RUN chmod -R a+rX /app && find /app/scripts -type f -name "*.sh" -exec chmod +x {} \;
+
 ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,72 +1,45 @@
+# Global base-image args for both stages
+ARG BASE_IMAGE=python:3.11-slim
+ARG RUNTIME_BASE_IMAGE=python:3.11-slim
+
 # ========= stage: builder =========
-FROM python:3.11-slim AS builder
+FROM ${BASE_IMAGE} AS builder
 ENV PYTHONUNBUFFERED=1 PIP_NO_CACHE_DIR=1
 ARG PORTABLE_BUILD=0
 ARG EOPF_GEOZARR_REF=main
 ARG EOPF_GEOZARR_SUBDIR=
 ARG DM_RAW_BASE=https://raw.githubusercontent.com/EOPF-Explorer/data-model
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates curl git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       ca-certificates curl git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Toolchain + GDAL/PROJ for sdist builds (enabled when PORTABLE_BUILD=1)
-RUN if [ "$PORTABLE_BUILD" = "1" ]; then \
-      apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        build-essential pkg-config \
-        gdal-bin libgdal-dev \
-        proj-bin libproj-dev \
-      && rm -rf /var/lib/apt/lists/* ; \
-    fi
+# Optional toolchain + GDAL/PROJ for sdists (needed in portable mode or fallback)
 ENV GDAL_CONFIG=/usr/bin/gdal-config
 
 # Pull lockfiles from data-model@<ref> (optionally a subdir)
-RUN set -eux; \
-    mkdir -p /tmp/dm; \
-    curl -fsSL -o /tmp/dm/pyproject.toml "${DM_RAW_BASE}/${EOPF_GEOZARR_REF}/${EOPF_GEOZARR_SUBDIR}pyproject.toml"; \
-    curl -fsSL -o /tmp/dm/uv.lock        "${DM_RAW_BASE}/${EOPF_GEOZARR_REF}/${EOPF_GEOZARR_SUBDIR}uv.lock"; \
-    test -s /tmp/dm/pyproject.toml && test -s /tmp/dm/uv.lock
+RUN set -eux;     mkdir -p /tmp/dm;     curl -fsSL -o /tmp/dm/pyproject.toml "${DM_RAW_BASE}/${EOPF_GEOZARR_REF}/${EOPF_GEOZARR_SUBDIR}pyproject.toml";     curl -fsSL -o /tmp/dm/uv.lock        "${DM_RAW_BASE}/${EOPF_GEOZARR_REF}/${EOPF_GEOZARR_SUBDIR}uv.lock";     test -s /tmp/dm/pyproject.toml && test -s /tmp/dm/uv.lock
 
-# uv + export pinned requirements (filter out self)
+# uv + export pinned third-party requirements (exclude eopf-geozarr itself)
 RUN pip install -U pip uv && uv --version
-RUN set -euo pipefail; \
-    cd /tmp/dm; \
-    uv export --locked --format=requirements-txt --no-hashes -o /tmp/req.raw.txt; \
-    awk 'BEGIN{IGNORECASE=1} \
-      /^-e[[:space:]]/ || /^--editable[[:space:]]/ {next} \
-      /@ file:/ || /file:\/\// {next} \
-      /^eopf-geozarr([[:space:]]|==|$)/ {next} \
-      /^[[:space:]]*#/ || /^[[:space:]]*$/ {next} \
-      {print}' /tmp/req.raw.txt > /tmp/requirements.txt
+RUN set -euo pipefail;     cd /tmp/dm;     uv export --locked --format=requirements-txt --no-hashes -o /tmp/req.raw.txt;     awk 'BEGIN{IGNORECASE=1}       /^-e[[:space:]]/ || /^--editable[[:space:]]/ {next}       /@ file:/ || /file:\/\// {next}       /^eopf-geozarr([[:space:]]|==|$)/ {next}       /^[[:space:]]*#/ || /^[[:space:]]*$/ {next}       {print}' /tmp/req.raw.txt > /tmp/requirements.txt
 
-# Install third-party deps
-# - portable (PORTABLE_BUILD=1): allow sdists (toolchain present)
-# - wheel mode (PORTABLE_BUILD=0): force wheels only → fail fast if missing
-RUN if [ "$PORTABLE_BUILD" = "1" ]; then \
-      uv pip install --system --requirements /tmp/requirements.txt ; \
-    else \
-      env PIP_ONLY_BINARY=":all:" uv pip install --system --requirements /tmp/requirements.txt ; \
-    fi
+# Install third-party deps with resilient strategy
+RUN set -eux;   if [ "$PORTABLE_BUILD" = "1" ]; then     echo "PORTABLE_BUILD=1: installing build deps + GDAL/PROJ first";     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       build-essential pkg-config       gdal-bin libgdal-dev       proj-bin libproj-dev     && rm -rf /var/lib/apt/lists/*;     export GDAL_CONFIG=/usr/bin/gdal-config;     uv pip install --system --requirements /tmp/requirements.txt;   else     echo "Fast path: wheels-only, with automatic fallback to sdists if needed";     if env PIP_ONLY_BINARY=":all:" uv pip install --system --requirements /tmp/requirements.txt; then       echo "Wheels-only install succeeded.";     else       echo "Wheels-only failed; installing build deps + GDAL/PROJ and retrying from sdist...";       apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         build-essential pkg-config         gdal-bin libgdal-dev         proj-bin libproj-dev       && rm -rf /var/lib/apt/lists/*;       export GDAL_CONFIG=/usr/bin/gdal-config;       uv pip install --system --requirements /tmp/requirements.txt;     fi;   fi
 
-# Install eopf-geozarr itself (no deps; already synced)
-RUN set -eux; \
-    if [ -n "$EOPF_GEOZARR_SUBDIR" ]; then \
-      PKG_URL="eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model@${EOPF_GEOZARR_REF}#subdirectory=${EOPF_GEOZARR_SUBDIR%/}"; \
-    else \
-      PKG_URL="eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model@${EOPF_GEOZARR_REF}"; \
-    fi; \
-    uv pip install --system --no-deps "$PKG_URL"
+# Install eopf-geozarr itself (follow the data-model repo @ref/subdir)
+RUN set -eux;     if [ -n "$EOPF_GEOZARR_SUBDIR" ]; then       PKG_URL="eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model@${EOPF_GEOZARR_REF}#subdirectory=${EOPF_GEOZARR_SUBDIR%/}";     else       PKG_URL="eopf-geozarr @ git+https://github.com/EOPF-Explorer/data-model@${EOPF_GEOZARR_REF}";     fi;     uv pip install --system --no-deps "$PKG_URL"
 
 RUN python -m compileall -q /usr/local/lib/python3.11/site-packages || true
 
 # ========= stage: runtime =========
-FROM python:3.11-slim AS runtime
+FROM ${RUNTIME_BASE_IMAGE} AS runtime
+ARG CACHE_BUST=0
+LABEL cache.bust="${CACHE_BUST}"
 ENV PYTHONUNBUFFERED=1
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      libstdc++6 libgomp1 libexpat1 \
-      gdal-bin proj-bin curl \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends       libstdc++6 libgomp1 libexpat1       gdal-bin proj-bin curl     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=builder /usr/local /usr/local
-CMD ["python","-V"]
+COPY scripts/ /app/scripts/
+RUN chmod -R a+rX /app && find /app/scripts -type f -name "*.sh" -exec chmod +x {} \; 
+ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,6 @@ ENV PYTHONUNBUFFERED=1 \
 ARG PORTABLE_BUILD=0
 # Git ref of the eopf-geozarr source (branch, tag, or commit)
 ARG EOPF_GEOZARR_REF=main
-# Optional subdirectory within the repo (empty means repo root)
-ARG EOPF_GEOZARR_SUBDIR=
 # Repo URL for the data-model project containing eopf-geozarr
 ARG EOPF_GEOZARR_REPO_URL=https://github.com/EOPF-Explorer/data-model.git
 
@@ -45,7 +43,6 @@ RUN set -eux; \
     echo "Cloning ${EOPF_GEOZARR_REPO_URL} @ ${EOPF_GEOZARR_REF} ..."; \
     git clone --depth 1 --branch "${EOPF_GEOZARR_REF}" "${EOPF_GEOZARR_REPO_URL}" /tmp/data-model; \
     cd /tmp/data-model; \
-    if [ -n "${EOPF_GEOZARR_SUBDIR}" ]; then cd "${EOPF_GEOZARR_SUBDIR}"; fi; \
     if uv pip install --system .; then \
     echo "Installed eopf-geozarr successfully (no native build needed)."; \
     else \

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -1,0 +1,22 @@
+
+# Overview
+
+**Goal:** Convert Sentinel Zarr → GeoZarr using a simple Argo pipeline.
+
+- **Local prototype**: run in k3d/k3s with minimal setup.
+- **Inputs**: Sentinel STAC URL, group(s) to convert.
+- **Outputs**: GeoZarr-compliant dataset in PVC.
+
+## Flow
+
+1. **Bootstrap** tools (docker, k3d, kubectl, argo CLI).  
+2. **Cluster**: ensure local k3d cluster exists.  
+3. **Argo**: install controller + CRDs (v3.6.5).  
+4. **Image**: build and import `eopf-geozarr:dev`.  
+5. **PVC**: create if needed.  
+6. **WorkflowTemplate**: applied to cluster.  
+7. **Submit**: run conversion job.
+
+---
+
+This structure maps directly to `make up` → `make logs`.

--- a/docs/01-local-prototype.md
+++ b/docs/01-local-prototype.md
@@ -1,0 +1,81 @@
+# Local prototype (k3d + Argo v3.6.5)
+
+## Install tools (automatic)
+
+If you're on **macOS (Homebrew)** or **Ubuntu/Debian**, run:
+
+```bash
+make bootstrap
+```
+
+This installs: Docker (macOS: cask), k3d, kubectl, argo CLI.
+
+If you prefer manual setup, see below.
+
+## Bring up the stack
+
+```bash
+# Create (or reuse) the local cluster
+k3d cluster create k3s-default || true
+
+# Build image, import into cluster, install Argo 3.6.5, ensure ns+PVC, apply template, submit
+make up
+
+# Stream logs
+make logs
+```
+
+## Custom run
+
+```bash
+make submit \
+  STAC_URL="https://your.host/path/in.zarr" \
+  OUTPUT_ZARR="/data/out_geozarr.zarr" \
+  GROUPS="measurements/reflectance/r20m" \
+  VALIDATE_GROUPS=false
+```
+
+## Fetching outputs
+
+The result lives in the PVC. Quick way to copy out via a transient pod:
+
+```bash
+# Name of the latest pod running your step
+POD=$(make -s pod)
+
+# Copy from the PVC-mounted path to your local machine
+kubectl -n ${NAMESPACE:-argo} cp "$POD":/data/out_geozarr.zarr ./out_geozarr.zarr
+```
+
+## Manual installs (reference)
+
+### macOS (Homebrew)
+
+```bash
+brew install k3d kubernetes-cli
+brew install argoproj/tap/argo
+brew install --cask docker
+open -a Docker
+```
+
+### Ubuntu/Debian (apt + curl)
+
+```bash
+# Docker
+sudo apt-get update && sudo apt-get install -y docker.io curl ca-certificates
+
+# k3d
+curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+# kubectl (latest stable)
+curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+# argo CLI
+curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.6.5/argo-linux-amd64.gz
+gunzip argo-linux-amd64.gz
+chmod +x argo-linux-amd64
+sudo mv argo-linux-amd64 /usr/local/bin/argo
+```
+
+> If you’re on Windows, use WSL2 and follow the Ubuntu/Debian steps.

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -1,0 +1,22 @@
+# Parameters
+
+| Name              | Source            | Default              | Notes |
+|-------------------|-------------------|----------------------|-------|
+| `NAMESPACE`       | Make env          | `argo`               | Kubernetes namespace for Argo + PVC. |
+| `PVC_NAME`        | Make env          | `geozarr-pvc`        | PVC bound and mounted at `/data`. |
+| `IMAGE`           | Make env          | `eopf-geozarr:dev`   | Container image tag used by template. |
+| `ARGO_VER`        | Make env          | `v3.6.5`             | Argo Workflows version to install. |
+| `STAC_URL`        | submit param      | *(none)*             | Input Sentinel-2 Zarr location (HTTP/S3/Swift). |
+| `OUTPUT_ZARR`     | submit param      | `/data/out.zarr`     | Output path on PVC. |
+| `GROUPS`          | submit param      | `measurements/reflectance/r20m` | Path(s) within Zarr to convert (CLI supports multiple). |
+| `VALIDATE_GROUPS` | submit param      | `false`              | When `true`, fail if group is missing. |
+
+### Examples
+
+```bash
+make submit \
+  STAC_URL="https://example.invalid/in.zarr" \
+  OUTPUT_ZARR="/data/out_geozarr.zarr" \
+  GROUPS="measurements/reflectance/r20m" \
+  VALIDATE_GROUPS=true
+```

--- a/docs/03-troubleshooting.md
+++ b/docs/03-troubleshooting.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+**No k3d cluster**: `FATA[0000] failed to get cluster ... No nodes found`  
+→ `k3d cluster create k3s-default` (Makefile targets are idempotent).
+
+**Namespace not found**: `namespaces "argo" not found`  
+→ Our `ensure_pvc.sh` creates the namespace if needed. Run `make up` again.
+
+**No WorkflowTemplate CRD**: `no matches for kind "WorkflowTemplate"`  
+→ `make up` installs Argo v3.6.5 and waits for CRDs. Verify: `kubectl api-resources | grep WorkflowTemplate`.
+
+**YAML parse error** when applying template  
+→ We ship a validated template. To lint changes: `kubectl create --dry-run=client -f workflows/geozarr-convert-template.yaml`.
+
+**Image not visible inside cluster**  
+→ Use our default `k3d image import` path; or set `USE_REGISTRY=1` and push to the local k3d registry.
+
+**Object storage auth** (future)  
+→ For OVH object storage, mount credentials as a Secret and inject env vars; see `docs/10-roadmap-ovh.md`.

--- a/docs/10-roadmap-ovh.md
+++ b/docs/10-roadmap-ovh.md
@@ -1,0 +1,20 @@
+# Roadmap to OVH (next steps)
+
+**Goal**: run the same Argo templates on an OVH-hosted Kubernetes cluster and scale out.
+
+## Storage
+- Start with OVH Block Storage (RWO PVC) to mirror local behavior.
+- For higher concurrency and read/write throughput, plan for **object store outputs** (Swift/S3 API). Container writes directly to object storage; PVC only for scratch.
+
+## Scaling
+- Increase throughput by fan-out per *group/band/tile*. Use a DAG with parallel steps.
+- Control parallelism at **workflow** and **controller** levels; set resources per template (CPU/memory).
+
+## Images
+- Push to an OVH-accessible registry (Harbor/CR/Hub). Add `imagePullSecrets` when needed.
+
+## Security
+- Minimal ServiceAccount/RBAC for workflows. Restrict egress to object storage endpoints if required.
+
+## CI/CD
+- GitHub Actions: build multi-arch images, tag with commit SHA, apply manifests to staging using `kubectl diff` + `kubectl apply`.

--- a/docs/99-dev-notes.md
+++ b/docs/99-dev-notes.md
@@ -1,0 +1,9 @@
+# Dev notes
+
+- Pinned versions: Argo **v3.6.5**, Python **3.11-slim**.
+- Local loops:
+  - `make build` → build container
+  - `make template && make submit` → re-register and run
+- Future tests:
+  - small synthetic Zarr fixtures + golden outputs
+  - parameter validation: missing groups should fail when `VALIDATE_GROUPS=true`

--- a/docs/DESIGN_BRIEF.md
+++ b/docs/DESIGN_BRIEF.md
@@ -1,6 +1,6 @@
 # LLM_BRIEF.md — data-model-pipeline (Argo → GeoZarr)
 
-**Goal:** Convert **STAC Zarr** → **GeoZarr** using `eopf-geozarr` (from `EOPF-Explorer/data-model`) orchestrated by **Argo Workflows**. This brief gives you, an LLM, the exact constraints and context to optimize the repo without breaking behavior.
+**Goal:** Convert **STAC Zarr** → **GeoZarr** using `eopf-geozarr` (from `EOPF-Explorer/data-model`) orchestrated by **Argo Workflows**. This brief gives constraints and context to optimize the repo without breaking behavior.
 
 ## Must-keep invariants
 - CLI: `eopf-geozarr convert <input_path> <output_path> --groups <g1 g2 ...>` (positional input/output).
@@ -13,8 +13,7 @@
   - unbuffered, chatty logs; exit non-zero on hard failures
 - WorkflowTemplate mounts a PVC at `/data`; `output_zarr` must live there.
 - Local image imported into k3d; `imagePullPolicy: IfNotPresent`.
-- Namespace: `argo`; Argo v3.6.5.
-- Single `params.json` (no `.example`).
+- Single `params.json`).
 
 ## External interfaces
 **Workflow parameters**: `image`, `pvc_name`, `stac_url`, `output_zarr`, `groups`, `validate_groups` (bool-like).  

--- a/docs/DESIGN_EXPLAINER.md
+++ b/docs/DESIGN_EXPLAINER.md
@@ -1,0 +1,236 @@
+
+# data-model-pipeline — Explainer & Optimization Brief (for LLMs)
+
+This repo is an **Argo-native orchestration layer** that converts **STAC Zarr** items into **GeoZarr** using the `eopf-geozarr` CLI from the upstream **data-model** repo (`EOPF-Explorer/data-model`). It supplies the **runner image**, the **Argo WorkflowTemplate**, a small **Bash wrapper** around the CLI, and **Make targets** for a smooth local-dev loop on **k3d/k3s**.
+
+The goal of this document is to pass all *relevant operational context* and *design constraints* to another LLM so it can further **simplify**, **optimize**, and **harden** the pipeline **without breaking the working flow**.
+
+---
+
+## TL;DR — What must keep working
+
+- **CLI contract** (from `data-model`):  
+  `eopf-geozarr convert <input_path> <output_path> --groups <one or more group paths> [--dask-cluster] [--verbose]`  
+  *Important:* `convert` expects **positional** `input` and `output`. Default groups in the CLI are `["/measurements/r10m", "/measurements/r20m", "/measurements/r60m"]`, but here we pass **explicit groups**.
+- **Wrapper** (`scripts/convert.sh`): parses flags, **normalizes group paths** (adds leading `/`), **preflights** the Zarr store to list available groups, and fails with **actionable suggestions** if a group is missing.
+- **WorkflowTemplate**: minimal & valid Argo spec, **no dev-only params** (`dask_perf_html` removed), PVC mounted at `/data`, `imagePullPolicy: IfNotPresent`.
+- **Image**: built locally and **imported into k3d**, so the pod doesn’t need to pull from registries.
+- **Namespace**: everything targets **`argo`** (not `argo-workflows`). Argo version used in manifests/logs is **v3.6.5**.
+
+---
+
+## Repo Layout (essential files)
+
+- `docker/Dockerfile` — builds the runner image:
+  - Installs `eopf-geozarr` from the **data-model** repo via `pip install git+…`.
+  - If `rasterio` fails to import, installs **GDAL/PROJ** system packages and retries pip install (wheels → source build fallback).
+  - Ensures `scripts/*.sh` are **executable** after `COPY`.
+- `scripts/convert.sh` — **wrapper** that:
+  - accepts `--stac-url`, `--output-zarr`, `--groups …`
+  - **normalizes** groups to absolute paths (`/…`), falls back to `$ARGO_GROUPS` if empty/`0`
+  - **preflights** (via `fsspec`) to list `.zgroup`s and **validate** requested groups (prints *Available/Missing/Suggestions*)
+  - calls: `eopf-geozarr convert "${STAC_URL}" "${OUTPUT_ZARR}" --groups "${NORM_GROUPS[@]}"`
+- `workflows/geozarr-convert-template.yaml` — **clean** Argo WorkflowTemplate:
+  - `entrypoint: geozarr-convert`, `serviceAccountName: default`
+  - parameters: `image`, `pvc_name`, `stac_url`, `output_zarr`, `groups`, `validate_groups`
+  - container runs `bash /app/scripts/convert.sh …`
+  - mounts PVC param at `/data` (used for `output_zarr`)
+- `params.json` — the **only** param file; no `.example`:
+  ```json
+  {
+    "arguments": {
+      "parameters": [
+        { "name": "stac_url", "value": "<S2 Zarr URL>" },
+        { "name": "output_zarr", "value": "/data/<name>_geozarr.zarr" },
+        { "name": "groups", "value": "measurements/reflectance/r20m" },
+        { "name": "validate_groups", "value": "false" }
+      ]
+    }
+  }
+  ```
+- `Makefile` — streamlined targets: `build`, `load-k3d`, `argo-install`, `template`, `submit`, `status`, `pod`, `events`, `logs`, `doctor`, and a **cluster GC** target for k3d disk pressure.
+
+---
+
+## Why changes were made (context from prior failures)
+
+1. **YAML parse errors** (`could not find expected ':'`, line ~64):  
+   - Caused by quoting/indent footguns and unused params. → Rewrote a minimal `WorkflowTemplate` with **explicit quoting**, removed `dask_perf_html`.
+
+2. **Wrong CLI flags** (`unrecognized arguments: --stac-url --output-zarr`):  
+   - The CLI expects **positional** args; the wrapper now converts flags to positional on the final `eopf-geozarr convert …` call.
+3. **Group mismatch** (`Could not find node at 0`):  
+   - `groups` like `measurements/reflectance/r20m` (no leading `/`) didn’t match store layout. → Wrapper **normalizes** groups and **preflights** to show *Available/Missing/Suggestions*.
+4. **`Permission denied` on `/app/scripts/convert.sh`**:  
+   - File mode lost on COPY. → Dockerfile now `chmod +x` after copying.
+5. **`ErrImagePull` / `ErrImageNeverPull`** with **local tags**:
+   - Fixed by `imagePullPolicy: IfNotPresent` and **importing** the image to k3d (`k3d image import …`).
+6. **Workflows stuck `Pending` with no pod**:  
+   - Root cause: **Argo controller** missing or not running in the `argo` namespace. → Install **v3.6.5** into `argo`, confirm CRDs, ensure controller is **Running**.
+7. **Controller pod stuck `Pending`**:
+   - Root cause: **DiskPressure** taints on k3d nodes. → **Prune containerd** content inside node containers and restart rollout.
+8. **Submit to wrong namespace / entrypoint**:  
+   - Ensured `namespace: argo`, `entrypoint` set, `serviceAccountName: default` set explicitly.
+9. **Dependency build failures** (`numpy==2.0.0rc1`, `rasterio` wheels missing):
+   - Use **wheels-first**, then fallback to installing GDAL toolchain & source build. Consider aligning Python version with wheels (py310/py311) and using upstream lock (see *Future improvements*).
+
+---
+
+## Known-good quickstart
+
+```bash
+# Image
+docker build -t eopf-geozarr:dev -f docker/Dockerfile .
+k3d image import --cluster k3s-default eopf-geozarr:dev
+
+# Argo (namespace argo, version v3.6.5)
+kubectl create ns argo --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -n argo -f https://github.com/argoproj/argo-workflows/releases/download/v3.6.5/install.yaml
+
+# If controller is Pending due to DiskPressure (k3d):
+#   docker exec k3d-k3s-default-server-0 sh -lc 'crictl rmp -fa; crictl rmi --prune; ctr -n k8s.io images prune; ctr -n k8s.io content gc'
+#   docker exec k3d-k3s-default-agent-0  sh -lc 'crictl rmp -fa; crictl rmi --prune; ctr -n k8s.io images prune; ctr -n k8s.io content gc'
+
+kubectl -n argo rollout status deploy/workflow-controller
+
+# Template
+kubectl apply -n argo -f workflows/geozarr-convert-template.yaml
+
+# Submit (edit values or use params.json via argo submit -f)
+argo submit -n argo --from workflowtemplate/geozarr-convert   -p image=eopf-geozarr:dev   -p pvc_name=geozarr-pvc   -p stac_url="<S2 Zarr URL>"   -p output_zarr="/data/<name>_geozarr.zarr"   -p groups="measurements/reflectance/r20m"   -p validate_groups=false
+
+# Observe
+kubectl -n argo get pods
+# Tail logs (main container)
+#   kubectl -n argo logs -f <pod> -c main
+```
+
+**Artifacts**: the converted GeoZarr goes to the PVC at the `output_zarr` path. (If a tarball step is needed later, add a second step or post-command tar.)
+
+---
+
+## Troubleshooting playbook (copy/paste friendly)
+
+### YAML / Template
+- Parse error on apply → check quoting, or re-apply the **minimal** template in this repo.
+
+### Workflow stuck `Pending` (no pod created)
+```bash
+kubectl get crd workflows.argoproj.io workflowtemplates.argoproj.io
+kubectl -n argo get deploy,po -l app=workflow-controller
+# If missing or not Running → reinstall v3.6.5 in ns=argo
+```
+
+### Controller pod `Pending`
+```bash
+kubectl -n argo describe rs $(kubectl -n argo get rs -l app=workflow-controller -o jsonpath='{.items[-1:].metadata.name}') | sed -n '/Events:/,$p'
+
+# If DiskPressure:
+docker exec k3d-k3s-default-server-0 sh -lc 'crictl rmp -fa; crictl rmi --prune; ctr -n k8s.io images prune; ctr -n k8s.io content gc'
+docker exec k3d-k3s-default-agent-0  sh -lc 'crictl rmp -fa; crictl rmi --prune; ctr -n k8s.io images prune; ctr -n k8s.io content gc'
+kubectl -n argo rollout restart deploy/workflow-controller
+```
+
+### Image pull issues (workflow pod)
+- Import the exact tag into k3d: `k3d image import --cluster k3s-default eopf-geozarr:dev`
+- Ensure the template uses `imagePullPolicy: IfNotPresent`.
+
+### Exec permission denied (wrapper)
+- Ensure Dockerfile performs `chmod +x /app/scripts/*.sh` after `COPY`.
+- Call wrapper as `bash /app/scripts/convert.sh …` (works even if mode flips).
+
+### Group/path errors (`Could not find node at 0`)
+- Use **absolute** group paths (leading `/`).  
+- The wrapper will list available groups and **suggest** close matches.
+
+---
+
+## Design choices worth preserving
+
+- **Separation of concerns**: converter lives in `data-model`; this repo is orchestration only.
+- **No duplicate config**: single `params.json`, no `.example` file.
+- **Validate early**: group preflight prevents opaque failures later.
+- **Local-first images**: avoid registry pulls in inner dev loop.
+- **Minimal Argo template**: fewer knobs ⇒ fewer YAML footguns.
+
+---
+
+## Optimization ideas (safe to pursue)
+
+1. **Dependency alignment with `data-model`:**
+   - Consume upstream lock (e.g., `uv.lock` or pinned constraints). Option A: `pip install -r` exported from upstream lock. Option B: `uv pip sync` for exact third-party deps, then `pip install --no-deps eopf-geozarr` from the same ref.
+   - Ensure Python ABI matches wheels for GDAL stack (py310/py311).
+2. **Image size & build speed:**
+   - Multi-stage: keep GDAL/PROJ only in runtime if needed; test `manylinux` wheels first, avoid dev headers in final layer.
+   - Consider `micromamba` for native libs where wheels lack coverage.
+3. **Argo improvements:**
+   - Add resource requests/limits; expose as params if needed.
+   - Optional: second step to tar outputs to `/outputs/geozarr.tar.gz` as artifact.
+   - Structured logs & more explicit failure messages.
+4. **DX polish:**
+   - `make doctor`: already present; extend with “controller ns mismatch” checks.
+   - `make argo-install`: pin version (v3.6.5) and verify CRDs + controller pods.
+   - Add `make cluster-gc` (k3d containerd GC) target by default.
+5. **Tests & reproducibility:**
+   - Small **golden** STAC Zarr + expected GeoZarr for a CI smoke.
+   - `act`/`kind` or a light e2e workflow locally.
+6. **Packaging:**
+   - Optional Helm chart containing the WorkflowTemplate + PVC.
+   - GHCR publishing of runner image on tags/commits.
+
+---
+
+## Guardrails for future edits (for LLMs)
+
+- Do **not** reintroduce `dask_perf_html` in the template (dev-only).
+- Do **not** change CLI invocation off positional args.
+- Always **normalize** and **validate** group paths before convert.
+- Keep `imagePullPolicy: IfNotPresent` and remember to **import** the image into k3d.
+- Keep the **namespace** consistent (`argo`), or make it a Makefile param *and* update `kubectl`/`argo` calls accordingly.
+- Preserve `params.json` as the single source of defaults.
+
+---
+
+## Handy snippets
+
+**Makefile target for k3d node GC**:
+```make
+CLUSTER ?= k3s-default
+cluster-gc:
+	@SERVER=$$(docker ps --format '{{.Names}}' | grep "k3d-$(CLUSTER)-server-0"); \
+	AGENT=$$(docker ps --format '{{.Names}}'  | grep "k3d-$(CLUSTER)-agent-0"); \
+	for n in $$SERVER $$AGENT; do \	  [ -z "$$n" ] && continue; \	  echo "== $$n =="; \	  docker exec "$$n" sh -lc 'set -e; \	    crictl rmp -fa || true; crictl rmi --prune || true; \	    ctr -n k8s.io images prune || true; ctr -n k8s.io content gc || true; \	    df -h /'; \	done
+```
+
+**zsh-safe DiskPressure query**:
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,DISK_PRESSURE:.status.conditions[?(@.type=="DiskPressure")].status'
+```
+
+**Describe newest controller ReplicaSet events**:
+```bash
+kubectl -n argo describe rs $(kubectl -n argo get rs -l app=workflow-controller -o jsonpath='{.items[-1:].metadata.name}') | sed -n '/Events:/,$p'
+```
+
+---
+
+## Final checklist for running
+
+- [ ] Argo CRDs exist & controller is **Running** in `argo` (v3.6.5).
+- [ ] Node **DiskPressure** is `False` on at least one node.
+- [ ] Runner image built & **imported** into k3d.
+- [ ] Template applied; `params.json` uses `/data/...` for outputs.
+- [ ] Submit with **absolute** group paths (or rely on wrapper normalization).
+- [ ] Use `make logs` or `kubectl logs -f <pod> -c main` to observe.
+
+---
+
+**Contact surface for the next LLM**  
+If you’re optimizing this further, start by:
+1) Reducing Docker image size while preserving GDAL/rasterio ergonomics.  
+2) Turning preflight into a tiny Python entrypoint (cleaner logging, unit tests).  
+3) Folding controller/bootstrap checks into `make doctor` with clear remedies.  
+
+---
+
+*(End of explainer)*

--- a/params.json
+++ b/params.json
@@ -1,17 +1,22 @@
 {
-  "namespace": "argo",
-  "resourceKind": "Workflow",
-  "resourceName": "",
-  "submitOptions": {},
-  "workflowTemplateRef": { "name": "geozarr-convert" },
   "arguments": {
     "parameters": [
       {
         "name": "stac_url",
         "value": "https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/18/products/cpm_v256/S2B_MSIL2A_20250518T112119_N0511_R037_T29RLL_20250518T140519.zarr"
       },
-      { "name": "output_zarr", "value": "./S2B_MSIL2A_20250518_T29RLL_geozarr.zarr" },
-      { "name": "groups", "value": "measurements/reflectance/r20m" }
+      {
+        "name": "output_zarr",
+        "value": "/data/S2B_MSIL2A_20250518_T29RLL_geozarr.zarr"
+      },
+      {
+        "name": "groups",
+        "value": "measurements/reflectance/r20m"
+      },
+      {
+        "name": "validate_groups",
+        "value": "false"
+      }
     ]
   }
 }

--- a/scripts/argo_set_auth_mode.py
+++ b/scripts/argo_set_auth_mode.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import sys
+import os
+
+
+def sh(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True)
+
+
+def patch_deploy(ns: str, mode: str) -> None:
+    # Get the current deployment
+    raw = sh(["kubectl", "-n", ns, "get", "deploy", "argo-server", "-o", "json"])
+    dep = json.loads(raw)
+
+    # Find argo-server container by name
+    containers = dep.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    if not containers:
+        print("argo-server deployment has no containers?", file=sys.stderr)
+        sys.exit(1)
+    name = "argo-server"
+    c = None
+    for _c in containers:
+        if _c.get("name") == name:
+            c = _c
+            break
+    if c is None:
+        # Fallback to first container
+        c = containers[0]
+        name = c.get("name", "argo-server")
+
+    # Ensure command starts argo server; if the command is odd (e.g. ['server']), replace with ['argocli','server']
+    cmd = (c.get("command") or [])[:]
+    if cmd:
+        if cmd[0].endswith("argo") and (len(cmd) == 1 or (len(cmd) > 1 and cmd[1] != "server")):
+            cmd = [cmd[0], "server"] + cmd[1:]
+        elif cmd == ["server"] or cmd == ["argo-server"]:
+            cmd = ["argocli", "server"]
+
+    # Build args: remove existing --auth-mode (both '--auth-mode foo' and '--auth-mode=foo'),
+    # and remove existing --secure flags (both forms). We'll re-add below as needed.
+    args = (c.get("args", []) or [])[:]
+    new_args: list[str] = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--auth-mode":
+            # skip this and its value if present
+            i += 2 if i + 1 < len(args) else 1
+            continue
+        if a.startswith("--auth-mode="):
+            i += 1
+            continue
+        if a == "--secure":
+            i += 2 if i + 1 < len(args) else 1
+            continue
+        if a.startswith("--secure="):
+            i += 1
+            continue
+        new_args.append(a)
+        i += 1
+    new_args.append(f"--auth-mode={mode}")
+
+    # Optionally control TLS: ARGO_SET_SECURE can be 'true'/'false'. If unset, leave as-is.
+    set_secure = os.environ.get("ARGO_SET_SECURE")
+    if set_secure is not None:
+        set_secure_val = str(set_secure).lower() in ("1", "true", "yes")
+        new_args.append(f"--secure={'true' if set_secure_val else 'false'}")
+
+    # Compose env: ensure ARGO_SERVER_AUTH_MODE is set
+    env = c.get("env", []) or []
+    env = [e for e in env if e.get("name") != "ARGO_SERVER_AUTH_MODE"]
+    env.append({"name": "ARGO_SERVER_AUTH_MODE", "value": mode})
+
+    # Prepare strategic merge patch targeting the container by name to avoid dropping sidecars
+    container_patch = {"name": name}
+    if cmd:
+        container_patch["command"] = cmd
+    container_patch["args"] = new_args
+    container_patch["env"] = env
+
+    patched = json.dumps({"spec": {"template": {"spec": {"containers": [container_patch]}}}})
+    sh(["kubectl", "-n", ns, "patch", "deploy", "argo-server", "--type=strategic", "-p", patched])
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--namespace", "-n", default="argo")
+    ap.add_argument("--mode", choices=["server", "client", "sso"], required=True)
+    a = ap.parse_args()
+    patch_deploy(a.namespace, a.mode)
+    print(f"Patched argo-server to --auth-mode={a.mode} in namespace {a.namespace}")

--- a/scripts/argo_ui_proxy.py
+++ b/scripts/argo_ui_proxy.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""
+Auth-injecting reverse proxy for Argo UI.
+
+Runs a local HTTP server that:
+- starts `kubectl port-forward` to svc/argo-server in the given namespace,
+- obtains a bearer token (kubectl create token / argo auth token),
+- forwards all requests to the argo-server via the port-forward,
+- injects `Authorization: Bearer <token>` so the UI works without manual auth,
+- ignores upstream self-signed TLS by default.
+
+Usage:
+  python3 scripts/argo_ui_proxy.py --namespace argo [--port 8081]
+
+Then open the printed http://127.0.0.1:<port> URL.
+Ctrl+C to stop (it cleans up the port-forward).
+"""
+from __future__ import annotations
+
+import argparse
+import atexit
+import http.client
+import os
+import socket
+import socketserver
+import ssl
+import subprocess
+import sys
+from http.server import BaseHTTPRequestHandler
+from urllib.parse import urlsplit
+
+
+def find_free_port(preferred: int | None = None) -> int:
+    if preferred:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            if s.connect_ex(("127.0.0.1", preferred)) != 0:
+                s.close()
+                return preferred
+        finally:
+            try:
+                s.close()
+            except Exception:
+                pass
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def get_token(ns: str) -> str | None:
+    # Prefer kubectl minting a short-lived token
+    try:
+        out = subprocess.check_output(
+            ["kubectl", "-n", ns, "create", "token", "argo-server", "--duration=1h"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return out
+    except Exception:
+        pass
+    # Fallback to Argo CLI
+    try:
+        out = subprocess.check_output(
+            ["argo", "auth", "token", "-n", ns],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return out
+    except Exception:
+        pass
+    return None
+
+
+def get_upstream_port(ns: str) -> int:
+    try:
+        p = subprocess.check_output(
+            [
+                "kubectl",
+                "-n",
+                ns,
+                "get",
+                "svc",
+                "argo-server",
+                "-o",
+                "jsonpath={.spec.ports[0].port}",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if p:
+            return int(p)
+    except Exception:
+        pass
+    return 2746
+
+
+def start_port_forward(ns: str, upstream_port: int) -> int:
+    local_port = find_free_port(upstream_port)
+    cmd = [
+        "kubectl",
+        "-n",
+        ns,
+        "port-forward",
+        "svc/argo-server",
+        f"{local_port}:{upstream_port}",
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    # Basic readiness wait
+    for _ in range(50):
+        try:
+            with socket.create_connection(("127.0.0.1", local_port), timeout=0.1):
+                break
+        except Exception:
+            pass
+    return local_port, proc
+
+
+def probe_scheme(host: str, port: int, token: str | None) -> str:
+    # Prefer HTTPS; some servers close on HEAD, so use GET
+    try:
+        ctx = ssl._create_unverified_context()  # nosec
+        conn = http.client.HTTPSConnection(host, port, context=ctx, timeout=3)
+        headers = {"Accept": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        conn.request("GET", "/api/v1/info", headers=headers)
+        resp = conn.getresponse()
+        resp.read()
+        return "https"
+    except Exception:
+        pass
+    # Fallback to HTTP
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=3)
+        headers = {"Accept": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        conn.request("GET", "/api/v1/info", headers=headers)
+        resp = conn.getresponse()
+        resp.read()
+        return "http"
+    except Exception:
+        pass
+    # Default to https if uncertain
+    return "https"
+
+
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_ANY(self):  # type: ignore[override]
+        server: ThreadingHTTPServer = self.server  # type: ignore[assignment]
+        upstream_host: str = server.upstream_host  # type: ignore[attr-defined]
+        upstream_port: int = server.upstream_port  # type: ignore[attr-defined]
+        upstream_scheme: str = server.upstream_scheme  # type: ignore[attr-defined]
+        token: str | None = server.bearer_token  # type: ignore[attr-defined]
+        ns: str = server.ns  # type: ignore[attr-defined]
+        upstream_svc_port: int = server.upstream_svc_port  # type: ignore[attr-defined]
+        path_prefix: str | None = getattr(server, "upstream_path_prefix", None)  # type: ignore[attr-defined]
+        inject_auth: bool = bool(getattr(server, "inject_auth", True))  # type: ignore[attr-defined]
+
+        # Build headers and sanitize
+        raw_headers = {k: v for k, v in self.headers.items()}
+
+        def sanitize_headers(h: dict[str, str]) -> dict[str, str]:
+            out: dict[str, str] = {}
+            hop = {"connection", "proxy-connection", "keep-alive", "transfer-encoding", "upgrade", "te"}
+            for k, v in h.items():
+                lk = k.lower()
+                # Drop hop-by-hop and sensitive/conflicting headers
+                if lk in hop or lk == "cookie" or lk == "authorization" or lk == "content-length":
+                    continue
+                # Ensure value is printable ASCII (no CR/LF/tab)
+                sv = str(v).replace("\r", "").replace("\n", "")
+                sv = "".join(ch for ch in sv if 32 <= ord(ch) <= 126)
+                out[k] = sv
+            return out
+
+        base_headers = sanitize_headers(raw_headers)
+        base_headers["Host"] = f"127.0.0.1:{upstream_port}"
+        base_headers["Connection"] = "close"
+        if inject_auth and token:
+            base_headers["Authorization"] = f"Bearer {token}"
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length > 0 else None
+
+        def forward_once(scheme: str):
+            if scheme == "https":
+                ctx = ssl._create_unverified_context()  # nosec
+                conn_ = http.client.HTTPSConnection(upstream_host, upstream_port, context=ctx, timeout=30)
+            else:
+                conn_ = http.client.HTTPConnection(upstream_host, upstream_port, timeout=30)
+            path_ = f"{path_prefix}{self.path}" if path_prefix else self.path
+            conn_.request(self.command, path_, body=body, headers=base_headers)
+            return conn_.getresponse()
+
+        def ensure_pf_alive():
+            # Restart port-forward if dead or not connectable
+            try:
+                if getattr(server, "pf_proc", None) is None or server.pf_proc.poll() is not None:  # type: ignore[attr-defined]
+                    # (Re)start
+                    if getattr(server, "mode", "port-forward") == "port-forward":  # type: ignore[attr-defined]
+                        new_port, new_proc = start_port_forward(ns, upstream_svc_port)
+                        server.upstream_port = new_port  # type: ignore[attr-defined]
+                        server.pf_proc = new_proc  # type: ignore[attr-defined]
+                        server.upstream_scheme = probe_scheme("127.0.0.1", new_port, token)  # type: ignore[attr-defined]
+                    else:
+                        # k8s-proxy mode: ensure kubectl proxy is running; if not, start it
+                        k8s_port = getattr(server, "k8s_proxy_port", 8001)  # type: ignore[attr-defined]
+                        try:
+                            with socket.create_connection(("127.0.0.1", k8s_port), timeout=0.2):
+                                pass
+                        except Exception:
+                            proc = subprocess.Popen(["kubectl", "proxy", f"--port={k8s_port}"])
+                            server.pf_proc = proc  # type: ignore[attr-defined]
+                            try:
+                                with socket.create_connection(("127.0.0.1", k8s_port), timeout=2):
+                                    pass
+                            except Exception:
+                                pass
+                        server.upstream_port = k8s_port  # type: ignore[attr-defined]
+                        server.upstream_scheme = "http"  # type: ignore[attr-defined]
+                else:
+                    # Quick TCP check
+                    with socket.create_connection(("127.0.0.1", server.upstream_port), timeout=0.2):  # type: ignore[attr-defined]
+                        pass
+            except Exception:
+                # Hard restart on any error
+                try:
+                    if getattr(server, "pf_proc", None) and server.pf_proc.poll() is None:  # type: ignore[attr-defined]
+                        server.pf_proc.terminate()  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+                if getattr(server, "mode", "port-forward") == "port-forward":  # type: ignore[attr-defined]
+                    new_port, new_proc = start_port_forward(ns, upstream_svc_port)
+                    server.upstream_port = new_port  # type: ignore[attr-defined]
+                    server.pf_proc = new_proc  # type: ignore[attr-defined]
+                    server.upstream_scheme = probe_scheme("127.0.0.1", new_port, token)  # type: ignore[attr-defined]
+                else:
+                    k8s_port = getattr(server, "k8s_proxy_port", 8001)  # type: ignore[attr-defined]
+                    proc = subprocess.Popen(["kubectl", "proxy", f"--port={k8s_port}"])
+                    server.pf_proc = proc  # type: ignore[attr-defined]
+                    server.upstream_port = k8s_port  # type: ignore[attr-defined]
+                    server.upstream_scheme = "http"  # type: ignore[attr-defined]
+
+        # Built-in health/debug endpoints
+        if self.path == "/_health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            info = {
+                "ns": ns,
+                "pf_port": upstream_port,
+                "scheme": upstream_scheme,
+                "has_token": bool(token),
+                "path_prefix": path_prefix or "",
+            }
+            self.wfile.write((str(info)).encode())
+            return
+        if self.path == "/_debug":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(
+                f"ns={ns}\nupstream_port={upstream_port}\nscheme={upstream_scheme}\npath_prefix={path_prefix}\n".encode()
+            )
+            return
+
+        try:
+            # Ensure upstream connectivity
+            ensure_pf_alive()
+            upstream_port = server.upstream_port  # type: ignore[attr-defined]
+            upstream_scheme = server.upstream_scheme  # type: ignore[attr-defined]
+
+            # Try sequence with retries: [current, flip], then restart and retry
+            def attempt_sequences():
+                schemes = [upstream_scheme, "http" if upstream_scheme == "https" else "https"]
+                last_exc = None
+                for sch in schemes:
+                    try:
+                        return forward_once(sch)
+                    except Exception as e:
+                        last_exc = e
+                        continue
+                ensure_pf_alive()
+                schemes = [server.upstream_scheme, "http" if server.upstream_scheme == "https" else "https"]  # type: ignore[attr-defined]
+                for sch in schemes:
+                    try:
+                        return forward_once(sch)
+                    except Exception as e:
+                        last_exc = e
+                        continue
+                raise last_exc if last_exc else RuntimeError("forward failed")
+
+            resp = attempt_sequences()
+
+            data = resp.read()
+
+            # Copy response headers (exclude hop-by-hop)
+            self.send_response(resp.status, resp.reason)
+            hop = {
+                "connection",
+                "keep-alive",
+                "proxy-authenticate",
+                "proxy-authorization",
+                "te",
+                "trailers",
+                "transfer-encoding",
+                "upgrade",
+            }
+            for k, v in resp.getheaders():
+                lk = k.lower()
+                if lk in hop:
+                    continue
+                if lk == "location":
+                    try:
+                        u = urlsplit(v)
+                        v = v.replace(f"{u.scheme}://{u.netloc}", f"http://{self.server.server_address[0]}:{self.server.server_address[1]}")  # type: ignore[attr-defined]
+                    except Exception:
+                        pass
+                self.send_header(k, v)
+            self.send_header("Connection", "close")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            if data:
+                self.wfile.write(data)
+        except Exception as e:
+            msg = f"Upstream error: {e}"
+            self.send_response(502, "Bad Gateway")
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(msg)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(msg.encode())
+
+    # Map common verbs
+    def do_GET(self):
+        self.do_ANY()
+
+    def do_POST(self):
+        self.do_ANY()
+
+    def do_PUT(self):
+        self.do_ANY()
+
+    def do_DELETE(self):
+        self.do_ANY()
+
+    def log_message(self, fmt, *args):
+        # Quiet unless verbose is enabled
+        verbose = getattr(self.server, "verbose", False)
+        if verbose:
+            sys.stderr.write("[proxy] " + fmt % args + "\n")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Auth-injecting Argo UI proxy")
+    ap.add_argument("--namespace", "-n", default=os.environ.get("NAMESPACE", "argo"))
+    ap.add_argument("--port", type=int, default=None, help="Local HTTP port (default: auto)")
+    ap.add_argument(
+        "--mode",
+        choices=["port-forward", "k8s-proxy"],
+        default=os.environ.get("ARGO_UI_PROXY_MODE", "port-forward"),
+        help="Upstream mode: connect via port-forward to svc/argo-server or via kubectl API server proxy",
+    )
+    ap.add_argument(
+        "--k8s-proxy-port",
+        type=int,
+        default=int(os.environ.get("K8S_PROXY_PORT", "8001")),
+        help="kubectl proxy port when mode=k8s-proxy",
+    )
+    ap.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    args = ap.parse_args()
+
+    ns = args.namespace
+    mode = args.mode
+    if mode == "port-forward":
+        upstream_port = get_upstream_port(ns)
+        pf_port, pf_proc = start_port_forward(ns, upstream_port)
+        atexit.register(lambda: pf_proc.terminate() if pf_proc and pf_proc.poll() is None else None)
+        token = get_token(ns)
+        scheme = probe_scheme("127.0.0.1", pf_port, token)
+        upstream_path_prefix = None
+        inject_auth = True
+    else:
+        # k8s-proxy mode: talk to local kubectl proxy and route to service proxy path; no auth injection needed
+        upstream_port = args.k8s_proxy_port
+        # ensure kubectl proxy is running
+        try:
+            with socket.create_connection(("127.0.0.1", upstream_port), timeout=0.5):
+                pf_proc = None
+        except Exception:
+            pf_proc = subprocess.Popen(["kubectl", "proxy", f"--port={upstream_port}"])  # nosec
+            atexit.register(lambda: pf_proc.terminate() if pf_proc and pf_proc.poll() is None else None)
+        token = None
+        scheme = "http"
+        upstream_path_prefix = f"/api/v1/namespaces/{ns}/services/https:argo-server:web/proxy"
+        inject_auth = False
+
+    http_port = find_free_port(args.port)
+    server = ThreadingHTTPServer(("127.0.0.1", http_port), ProxyHandler)
+    # Attach upstream config to server object
+    server.upstream_host = "127.0.0.1"  # type: ignore[attr-defined]
+    server.upstream_port = pf_port if mode == "port-forward" else upstream_port  # type: ignore[attr-defined]
+    server.upstream_scheme = scheme  # type: ignore[attr-defined]
+    server.bearer_token = token  # type: ignore[attr-defined]
+    server.ns = ns  # type: ignore[attr-defined]
+    server.upstream_svc_port = upstream_port  # type: ignore[attr-defined]
+    server.pf_proc = pf_proc if mode == "port-forward" else pf_proc  # type: ignore[attr-defined]
+    server.mode = mode  # type: ignore[attr-defined]
+    server.k8s_proxy_port = args.k8s_proxy_port  # type: ignore[attr-defined]
+    server.upstream_path_prefix = upstream_path_prefix  # type: ignore[attr-defined]
+    server.inject_auth = inject_auth  # type: ignore[attr-defined]
+    server.verbose = args.verbose  # type: ignore[attr-defined]
+
+    # Write port file for progress_ui discovery when started via Makefile
+    try:
+        workdir = os.path.join(os.getcwd(), ".work")
+        os.makedirs(workdir, exist_ok=True)
+        with open(os.path.join(workdir, "argo_ui_proxy.port"), "w", encoding="utf-8") as f:
+            f.write(str(http_port))
+    except Exception:
+        pass
+
+    print(f"Argo UI proxy ready at http://127.0.0.1:{http_port}")
+    if args.verbose:
+        if mode == "port-forward":
+            print(f"  Upstream: {scheme}://127.0.0.1:{pf_port} (svc/argo-server in ns={ns}, svcPort={upstream_port})")
+            if token:
+                print("  Injecting Bearer token into all requests.")
+            else:
+                print("  Warning: no token available; UI calls may 401.")
+        else:
+            print(f"  Upstream: http://127.0.0.1:{upstream_port}{upstream_path_prefix} (via kubectl proxy)")
+            print("  Cookie headers are stripped; no auth injection required.")
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            server.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+need() { command -v "$1" >/dev/null 2>&1 || return 0; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+echo "==> Bootstrapping prerequisites (Docker, k3d, kubectl, argo)"
+OS="$(uname -s || echo unknown)"
+
+if ! have docker; then
+  echo "Docker not found."
+  if [ "$OS" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+    echo "Installing Docker Desktop via Homebrew Cask..."
+    brew install --cask docker || true
+    echo "Please launch Docker.app manually the first time (open -a Docker)."
+  elif [ -f /etc/debian_version ]; then
+    echo "Installing docker.io via apt..."
+    sudo apt-get update && sudo apt-get install -y docker.io
+    sudo usermod -aG docker "$USER" || true
+    echo "You may need to log out/in to use Docker without sudo."
+  else
+    echo "Please install Docker manually: https://docs.docker.com/engine/install/"
+  fi
+fi
+
+if ! have k3d; then
+  if [ "$OS" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+    brew install k3d
+  else
+    curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+  fi
+fi
+
+if ! have kubectl; then
+  if [ "$OS" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+    brew install kubernetes-cli
+  else
+    curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+    chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  fi
+fi
+
+if ! have argo; then
+  if [ "$OS" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+    brew install argoproj/tap/argo
+  else
+    curl -sLO https://github.com/argoproj/argo-workflows/releases/download/v3.6.5/argo-linux-amd64.gz
+    gunzip argo-linux-amd64.gz
+    chmod +x argo-linux-amd64
+    sudo mv argo-linux-amd64 /usr/local/bin/argo
+  fi
+fi
+
+echo "==> Tools:"
+docker --version || true
+k3d version || true
+kubectl version --client=true --output=yaml | grep gitVersion || true || true
+argo version --short || true
+
+echo "Bootstrap complete."

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Robust wrapper for `eopf-geozarr convert`
+# - Accepts --stac-url, --output-zarr, --groups [multi-token or single string]
+# - Falls back to $GROUPS or $ARGO_GROUPS when --groups omitted
+# - Normalizes to absolute group paths
+# - Preflight discovers .zgroup entries; if missing:
+#     * auto-map by unique suffix match (best effort)
+#     * if VALIDATE_GROUPS=true and still missing → exit 8
+#     * else warn and continue
+# - Unbuffered logs & error trap
+
+set -Eeuo pipefail
+export PYTHONUNBUFFERED=1
+
+trap 'ec=$?; echo "[convert.sh] ERROR at line ${LINENO} (exit=${ec})" >&2' ERR
+echo "[convert.sh] Bash $(bash --version | head -n1)"
+echo "[convert.sh] PWD=$(pwd)"
+
+STAC_URL="${STAC_URL:-}"
+OUTPUT_ZARR="${OUTPUT_ZARR:-}"
+GROUPS="${GROUPS:-}"
+declare -a GROUPS_ARR=()
+VALIDATE_GROUPS="${VALIDATE_GROUPS:-false}"
+
+# --- parse flags ---
+while (($#)); do
+  case "$1" in
+    --stac-url)       STAC_URL="${2-}"; shift 2 ;;
+    --output-zarr)    OUTPUT_ZARR="${2-}"; shift 2 ;;
+    --groups)
+      shift
+      while (($#)) && [[ "$1" != --* ]]; do GROUPS_ARR+=("$1"); shift; done
+      ;;
+    --validate-groups) # allow optional true/false after it
+      if [[ "${2-}" != "" && "${2-}" != --* ]]; then VALIDATE_GROUPS="${2}"; shift 2; else VALIDATE_GROUPS="true"; shift; fi
+      ;;
+    *) echo "[convert.sh] Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Fallbacks
+if ((${#GROUPS_ARR[@]} == 0)); then
+  if [[ -n "${GROUPS:-}" ]]; then
+    read -r -a GROUPS_ARR <<< "${GROUPS}"
+  elif [[ -n "${ARGO_GROUPS:-}" ]]; then
+    read -r -a GROUPS_ARR <<< "${ARGO_GROUPS}"
+  fi
+fi
+
+[[ -n "${STAC_URL:-}" ]]    || { echo "[convert.sh] Missing --stac-url" >&2; exit 2; }
+[[ -n "${OUTPUT_ZARR:-}" ]] || { echo "[convert.sh] Missing --output-zarr" >&2; exit 2; }
+
+# Normalize
+declare -a NORM_GROUPS=()
+for g in "${GROUPS_ARR[@]:-}"; do
+  [[ -z "$g" ]] && continue
+  [[ "$g" == /* ]] && NORM_GROUPS+=("$g") || NORM_GROUPS+=("/$g")
+done
+if ((${#NORM_GROUPS[@]} == 0)) || { ((${#NORM_GROUPS[@]} == 1)) && [[ "${NORM_GROUPS[0]}" == "/0" ]]; }; then
+  echo "[convert.sh] Error: group list is empty. Provide --groups <...> or set ARGO_GROUPS." >&2
+  exit 5
+fi
+
+echo "[convert.sh] Parsed:"
+echo "  STAC_URL=${STAC_URL}"
+echo "  OUTPUT_ZARR=${OUTPUT_ZARR}"
+echo "  GROUPS(${#NORM_GROUPS[@]}): ${NORM_GROUPS[*]}"
+echo "  VALIDATE_GROUPS=${VALIDATE_GROUPS}"
+
+# --- CLI sanity ---
+if ! command -v eopf-geozarr >/dev/null 2>&1; then
+  echo "[convert.sh] eopf-geozarr not on PATH" >&2
+  python - <<'PY'
+import os, sys, sysconfig
+print("Python:", sys.version)
+print("sys.executable:", sys.executable)
+print("site:", sysconfig.get_paths())
+print("PATH:", os.environ.get("PATH",""))
+PY
+  exit 127
+fi
+echo "[convert.sh] CLI version:"
+eopf-geozarr --version || true
+
+echo "[convert.sh] Probing input (info)..."
+(eopf-geozarr info "${STAC_URL}" --verbose || true) | head -n 40 || true
+
+# --- Preflight with JSON output for mapping ---
+PF_JSON="/tmp/preflight.$RANDOM.json"
+python - <<'PY' "${STAC_URL}" "${PF_JSON}" "${NORM_GROUPS[@]}"
+import sys, json
+url = sys.argv[1]; out = sys.argv[2]; req = sys.argv[3:]
+result = {"available": [], "requested": req, "missing": [], "mapping": {}}
+try:
+    import fsspec
+    fs, path = fsspec.core.url_to_fs(url)
+    files = fs.find(path)
+    avail = sorted({ '/' + f[len(path):].lstrip('/')[:-7] for f in files if f.endswith('.zgroup') })
+    result["available"] = avail
+    missing = [g for g in req if g not in avail]
+    result["missing"] = missing
+    # Build a simple unique-suffix mapping where possible
+    for m in missing:
+        tail = m.split('/')[-1]
+        cands = [g for g in avail if g.endswith('/'+tail) or g == '/'+tail or g.endswith(m)]
+        if len(cands) == 1:
+            result["mapping"][m] = cands[0]
+    with open(out, "w") as f:
+        json.dump(result, f)
+    if missing:
+        print("[preflight] Available groups (first 60):", file=sys.stderr)
+        for g in avail[:60]: print("  -", g, file=sys.stderr)
+        print("[preflight] Missing:", missing, file=sys.stderr)
+        print("[preflight] Auto-mapping candidates:", json.dumps(result["mapping"], indent=2), file=sys.stderr)
+except Exception as e:
+    # Do not fail open-listing errors
+    print(f"[preflight] Warning: {e!r}; continuing...", file=sys.stderr)
+    with open(out, "w") as f:
+        json.dump(result, f)
+PY
+
+# Read mapping and possibly rewrite groups
+if [[ -f "${PF_JSON}" ]]; then
+  mapfile -t AVAIL < <(python - <<'PY' "${PF_JSON}" 'avail'
+import sys, json; d=json.load(open(sys.argv[1]))
+print("\n".join(d.get("available",[])))
+PY
+  ) || true
+  MISSING_COUNT=$(python - <<'PY' "${PF_JSON}"
+import sys, json; print(len(json.load(open(sys.argv[1])).get("missing",[])))
+PY
+  )
+  if [[ "${MISSING_COUNT}" != "0" ]]; then
+    # Attempt auto-map
+    readarray -t NEW_GROUPS < <(python - <<'PY' "${PF_JSON}" "${NORM_GROUPS[@]}"
+import sys, json
+d=json.load(open(sys.argv[1])); req=sys.argv[2:]; mp=d.get("mapping",{})
+out=[mp.get(g,g) for g in req]
+print("\n".join(out))
+PY
+    ) || true
+    if ((${#NEW_GROUPS[@]} > 0)); then
+      echo "[convert.sh] Auto-mapped groups -> ${NEW_GROUPS[*]}"
+      NORM_GROUPS=("${NEW_GROUPS[@]}")
+    fi
+    # If still missing and strict validation requested, bail
+    STRICT=$(echo "${VALIDATE_GROUPS}" | tr '[:upper:]' '[:lower:]')
+    if [[ "${STRICT}" == "true" ]]; then
+      echo "[convert.sh] VALIDATE_GROUPS=true and one or more groups missing; aborting." >&2
+      exit 8
+    else
+      echo "[convert.sh] Continuing despite missing groups (VALIDATE_GROUPS=false)." >&2
+    fi
+  fi
+fi
+
+# --- run conversion ---
+set -x
+eopf-geozarr convert "${STAC_URL}" "${OUTPUT_ZARR}" --groups "${NORM_GROUPS[@]}"
+set +x
+
+echo "[convert.sh] Done."

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -88,35 +88,65 @@ echo "[convert.sh] Probing input (info)..."
 # --- Preflight with JSON output for mapping ---
 PF_JSON="/tmp/preflight.$RANDOM.json"
 python - <<'PY' "${STAC_URL}" "${PF_JSON}" "${NORM_GROUPS[@]}"
-import sys, json
-url = sys.argv[1]; out = sys.argv[2]; req = sys.argv[3:]
-result = {"available": [], "requested": req, "missing": [], "mapping": {}}
-try:
+import sys
+import json
+
+
+def build_preflight(url, req):
+  result = {"available": [], "requested": req, "missing": [], "mapping": {}}
+  try:
     import fsspec
     fs, path = fsspec.core.url_to_fs(url)
     files = fs.find(path)
-    avail = sorted({ '/' + f[len(path):].lstrip('/')[:-7] for f in files if f.endswith('.zgroup') })
+    avail = []
+    for f in files:
+      if f.endswith(".zgroup"):
+        rel = f[len(path):].lstrip("/")
+        rel = "/" + rel[:-7]
+        avail.append(rel)
+    avail = sorted(set(avail))
+    # Fallback for endpoints that don't support listing: probe requested groups directly
+    if not avail and req:
+      try:
+        for g in req:
+          gp = path.rstrip("/") + "/" + g.lstrip("/") + "/.zgroup"
+          if fs.exists(gp):
+            avail.append(g if g.startswith("/") else "/" + g)
+      except Exception:
+        pass
     result["available"] = avail
     missing = [g for g in req if g not in avail]
     result["missing"] = missing
     # Build a simple unique-suffix mapping where possible
     for m in missing:
-        tail = m.split('/')[-1]
-        cands = [g for g in avail if g.endswith('/'+tail) or g == '/'+tail or g.endswith(m)]
-        if len(cands) == 1:
-            result["mapping"][m] = cands[0]
-    with open(out, "w") as f:
-        json.dump(result, f)
-    if missing:
-        print("[preflight] Available groups (first 60):", file=sys.stderr)
-        for g in avail[:60]: print("  -", g, file=sys.stderr)
-        print("[preflight] Missing:", missing, file=sys.stderr)
-        print("[preflight] Auto-mapping candidates:", json.dumps(result["mapping"], indent=2), file=sys.stderr)
-except Exception as e:
+      tail = m.split("/")[-1]
+      cands = [g for g in avail if g.endswith("/" + tail) or g == "/" + tail or g.endswith(m)]
+      if len(cands) == 1:
+        result["mapping"][m] = cands[0]
+  except Exception as e:
     # Do not fail open-listing errors
     print(f"[preflight] Warning: {e!r}; continuing...", file=sys.stderr)
+  return result
+
+
+if __name__ == "__main__":
+  url = sys.argv[1]
+  out = sys.argv[2]
+  req = sys.argv[3:]
+  res = build_preflight(url, req)
+  try:
     with open(out, "w") as f:
-        json.dump(result, f)
+      json.dump(res, f)
+  except Exception:
+    pass
+  if res.get("missing"):
+    print("[preflight] Available groups (first 60):", file=sys.stderr)
+    for g in res.get("available", [])[:60]:
+      print("  -", g, file=sys.stderr)
+    print("[preflight] Missing:", res["missing"], file=sys.stderr)
+    print(
+      "[preflight] Auto-mapping candidates:", json.dumps(res.get("mapping", {}), indent=2), file=sys.stderr
+    )
 PY
 
 # Read mapping and possibly rewrite groups
@@ -140,7 +170,10 @@ print("\n".join(out))
 PY
     ) || true
     if ((${#NEW_GROUPS[@]} > 0)); then
-      echo "[convert.sh] Auto-mapped groups -> ${NEW_GROUPS[*]}"
+      OLD_JOIN="${NORM_GROUPS[*]}"; NEW_JOIN="${NEW_GROUPS[*]}"
+      if [[ "${NEW_JOIN}" != "${OLD_JOIN}" ]]; then
+        echo "[convert.sh] Auto-mapped groups -> ${NEW_GROUPS[*]}"
+      fi
       NORM_GROUPS=("${NEW_GROUPS[@]}")
     fi
     # If still missing and strict validation requested, bail
@@ -154,9 +187,71 @@ PY
   fi
 fi
 
-# --- run conversion ---
-set -x
-eopf-geozarr convert "${STAC_URL}" "${OUTPUT_ZARR}" --groups "${NORM_GROUPS[@]}"
-set +x
+# --- run conversion with resilient retries ---
+# Tweakable via env:
+#   MAX_ATTEMPTS: total tries (default 6)
+#   BACKOFF_INITIAL: first backoff seconds (default 2)
+#   BACKOFF_MULTIPLIER: exponential base (default 2)
+#   BACKOFF_MAX: cap per-sleep seconds (default 60)
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-6}
+BACKOFF_INITIAL=${BACKOFF_INITIAL:-2}
+BACKOFF_MULTIPLIER=${BACKOFF_MULTIPLIER:-2}
+BACKOFF_MAX=${BACKOFF_MAX:-60}
 
-echo "[convert.sh] Done."
+LOG_FILE="/tmp/convert.$RANDOM.log"
+attempt=1
+last_ec=0
+
+should_retry() {
+  # Inspect log for transient network/server disconnect patterns
+  # Lowercase match to broaden coverage
+  tr '[:upper:]' '[:lower:]' <"$LOG_FILE" | grep -E -q \
+    "server disconnected|connection reset|read timed out|temporary|temporarily|eof|rst|connection.*closed|broken pipe|stream error|upstream error|502|503|504|network is unreachable|timed out|tls: handshake failure"
+}
+
+calc_backoff() {
+  # attempt starts at 1
+  local n=$((attempt-1))
+  local delay=$BACKOFF_INITIAL
+  # integer exponentiation loop (bash portable)
+  for _ in $(seq 1 $n); do
+    delay=$((delay * BACKOFF_MULTIPLIER))
+    [ $delay -gt $BACKOFF_MAX ] && { delay=$BACKOFF_MAX; break; }
+  done
+  # jitter 0..delay/4
+  local jitter=$((RANDOM % (delay/4 + 1)))
+  echo $((delay + jitter))
+}
+
+echo "[convert.sh] Starting conversion with up to ${MAX_ATTEMPTS} attempt(s)..."
+while (( attempt <= MAX_ATTEMPTS )); do
+  echo "[convert.sh] Attempt ${attempt}/${MAX_ATTEMPTS}"
+  : >"$LOG_FILE"
+  set -x
+  # capture exit of eopf-geozarr, not tee
+  eopf-geozarr convert "${STAC_URL}" "${OUTPUT_ZARR}" --groups "${NORM_GROUPS[@]}" 2>&1 | tee -a "$LOG_FILE"
+  last_ec=${PIPESTATUS[0]}
+  set +x
+  if [[ $last_ec -eq 0 ]]; then
+    echo "[convert.sh] Conversion succeeded on attempt ${attempt}."
+    echo "[convert.sh] Done."
+    exit 0
+  fi
+  # Check if transient and we have retries left
+  if should_retry && (( attempt < MAX_ATTEMPTS )); then
+    sleep_s=$(calc_backoff)
+    echo "[convert.sh] Transient failure detected (e=${last_ec}). Will retry after ${sleep_s}s..."
+    # Show a short tail for context
+    tail -n 20 "$LOG_FILE" >&2 || true
+    sleep "$sleep_s"
+    attempt=$((attempt+1))
+    continue
+  else
+    echo "[convert.sh] Non-retriable failure or attempts exhausted (e=${last_ec})."
+    tail -n 50 "$LOG_FILE" >&2 || true
+    exit $last_ec
+  fi
+done
+
+echo "[convert.sh] Exhausted retries without success (last exit=${last_ec})." >&2
+exit ${last_ec:-1}

--- a/scripts/ensure_pvc.sh
+++ b/scripts/ensure_pvc.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ns="${1:-argo}"
+pvc="${2:-geozarr-pvc}"
+
+# Ensure namespace exists (idempotent)
+if ! kubectl get namespace "${ns}" >/dev/null 2>&1; then
+  echo "Namespace '${ns}' not found. Creating..."
+  kubectl create namespace "${ns}"
+else
+  echo "Namespace '${ns}' exists."
+fi
+
+# Ensure PVC exists (idempotent)
+if kubectl get pvc -n "${ns}" "${pvc}" >/dev/null 2>&1; then
+  echo "PVC '${pvc}' already exists in namespace '${ns}'."
+  exit 0
+fi
+
+cat <<YAML | kubectl apply -n "${ns}" -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${pvc}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+YAML
+
+echo "PVC '${pvc}' created in namespace '${ns}'."

--- a/scripts/ensure_ui_access.sh
+++ b/scripts/ensure_ui_access.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+NS="${1:-argo}"
+echo "[ensure_ui_access] Namespace: $NS"
+
+kubectl -n "$NS" create sa argo-ui-dev --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "$NS" create rolebinding argo-ui-admin \
+  --clusterrole=admin \
+  --serviceaccount="$NS":argo-ui-dev \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Grant cluster-admin for frictionless local UI (includes access to cluster-scoped templates)
+kubectl create clusterrolebinding argo-ui-dev-cluster-admin \
+  --clusterrole=cluster-admin \
+  --serviceaccount="$NS":argo-ui-dev \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "[ensure_ui_access] ServiceAccount 'argo-ui-dev' ready with admin permissions."

--- a/scripts/fetch_from_pvc.sh
+++ b/scripts/fetch_from_pvc.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: fetch_from_pvc.sh <namespace> <pvc_name> <remote_path> <local_dir>
+NS="${1:-argo}"
+PVC="${2:-geozarr-pvc}"
+REMOTE="${3:-/data}"
+LOCAL_DIR="${4:-./out}"
+
+# Create a short-lived helper pod that mounts the PVC at /data and sleeps
+POD_NAME="fetch-pvc-$(date +%s)-$RANDOM"
+
+# Trim trailing slashes
+REMOTE=${REMOTE%/}
+LOCAL_DIR=${LOCAL_DIR%/}
+
+cat <<YAML | kubectl -n "$NS" apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_NAME}
+  labels:
+    app: pvc-fetch
+spec:
+  restartPolicy: Never
+  containers:
+  - name: fetch
+    image: busybox:1.36
+    command: ["sh","-c","sleep 3600"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: ${PVC}
+YAML
+
+# Wait for the pod to be Ready (or at least Running)
+echo "Waiting for helper pod ${POD_NAME} to be Running..."
+kubectl -n "$NS" wait --for=condition=Ready pod/"$POD_NAME" --timeout=60s >/dev/null 2>&1 || \
+  kubectl -n "$NS" wait --for=condition=ContainersReady pod/"$POD_NAME" --timeout=60s >/dev/null 2>&1 || true
+
+# Copy from the mounted PVC path to local
+SRC_PATH="${POD_NAME}:${REMOTE}"
+mkdir -p "$LOCAL_DIR"
+echo "Copying $SRC_PATH -> $LOCAL_DIR"
+if ! kubectl -n "$NS" cp "$SRC_PATH" "$LOCAL_DIR"; then
+  echo "kubectl cp failed; attempting tar stream..."
+  kubectl -n "$NS" exec "$POD_NAME" -- sh -c "cd / && tar cf - ${REMOTE#/}" | tar xvf - -C "$LOCAL_DIR"
+fi
+
+# Cleanup helper pod
+echo "Cleaning up helper pod ${POD_NAME}"
+kubectl -n "$NS" delete pod "$POD_NAME" --wait=false >/dev/null 2>&1 || true
+
+echo "Fetch complete: ${LOCAL_DIR}"

--- a/scripts/fix_kubeconfig.sh
+++ b/scripts/fix_kubeconfig.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: fix_kubeconfig.sh <cluster_name> <out_file>
+CLUSTER_NAME="${1:-k3s-default}"
+OUT_FILE="${2:-.work/kubeconfig}"
+
+mkdir -p "$(dirname "$OUT_FILE")"
+
+if ! command -v k3d >/dev/null 2>&1; then
+  echo "k3d not found; skipping kubeconfig generation." >&2
+  exit 0
+fi
+
+# Try to get kubeconfig; if it fails, attempt a merge to regenerate
+if ! k3d kubeconfig get "$CLUSTER_NAME" >/dev/null 2>&1; then
+  k3d kubeconfig merge "$CLUSTER_NAME" --kubeconfig-switch-context >/dev/null 2>&1 || true
+fi
+
+if k3d kubeconfig get "$CLUSTER_NAME" >/dev/null 2>&1; then
+  k3d kubeconfig get "$CLUSTER_NAME" | sed -e 's/0\.0\.0\.0/127.0.0.1/g' > "$OUT_FILE"
+  echo "Wrote kubeconfig to $OUT_FILE" >&2
+else
+  echo "Warning: could not obtain kubeconfig for cluster '$CLUSTER_NAME'." >&2
+  # Create an empty file so env var can still be exported without error
+  : > "$OUT_FILE"
+fi

--- a/scripts/params_to_flags.py
+++ b/scripts/params_to_flags.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import json, sys, shlex
+
+def main(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    params = []
+    # Support both plain and nested structures
+    param_list = []
+    if isinstance(data, dict):
+        if "arguments" in data and isinstance(data["arguments"], dict):
+            param_list = data["arguments"].get("parameters", [])
+        elif "parameters" in data:
+            param_list = data["parameters"]
+    for p in param_list:
+        name = p.get("name")
+        val = p.get("value", "")
+        if name is None:
+            continue
+        # shell-quote values defensively
+        params.append(f"-p {name}={shlex.quote(str(val))}")
+    print(" ".join(params))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("")
+    else:
+        main(sys.argv[1])

--- a/scripts/print_ui_link.py
+++ b/scripts/print_ui_link.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Start or reuse the local Argo UI HTTP proxy and print its URL. Optionally open it.
+
+This uses a small local proxy that injects Authorization for the Argo UI,
+so you can use a plain http://127.0.0.1:<port> link without manual tokens.
+"""
+
+import argparse
+import os
+import socket
+import subprocess
+import time
+import webbrowser
+
+
+def _start_auth_proxy_bg(ns: str) -> str | None:
+    """Start or reuse the local Argo UI HTTP proxy and return its URL."""
+    work = os.path.join(os.getcwd(), ".work")
+    os.makedirs(work, exist_ok=True)
+    port_file = os.path.join(work, "argo_ui_proxy.port")
+    # Reuse if already running
+    try:
+        if os.path.exists(port_file):
+            with open(port_file, "r", encoding="utf-8") as f:
+                p = f.read().strip()
+            if p.isdigit():
+                try:
+                    with socket.create_connection(("127.0.0.1", int(p)), timeout=0.3):
+                        return f"http://127.0.0.1:{p}"
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    # Start proxy
+    try:
+        subprocess.Popen(
+            ["python3", "scripts/argo_ui_proxy.py", "--namespace", ns],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Wait briefly for port file
+        t0 = time.time()
+        while time.time() - t0 < 5:
+            if os.path.exists(port_file):
+                try:
+                    with open(port_file, "r", encoding="utf-8") as f:
+                        p = f.read().strip()
+                    if p.isdigit():
+                        with socket.create_connection(("127.0.0.1", int(p)), timeout=0.5):
+                            return f"http://127.0.0.1:{p}"
+                except Exception:
+                    pass
+            time.sleep(0.1)
+    except Exception:
+        pass
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Start/reuse local Argo UI proxy and print its URL.")
+    ap.add_argument("--namespace", "-n", default=os.environ.get("NAMESPACE", "argo"), help="Kubernetes namespace")
+    ap.add_argument("--open", action="store_true", help="Open the URL in your default browser")
+    a = ap.parse_args()
+    ns = a.namespace
+
+    # Respect an externally provided proxy URL if set.
+    url = os.environ.get("ARGO_UI_PROXY_URL")
+    if not url:
+        url = _start_auth_proxy_bg(ns)
+
+    print("Argo UI (via local HTTP proxy):")
+    if url:
+        print(f"  {url}")
+        if a.open:
+            try:
+                webbrowser.open(url)
+            except Exception:
+                try:
+                    subprocess.run(["open", url], check=False)
+                except Exception:
+                    pass
+    else:
+        print("  (Proxy did not start. Ensure the cluster is up, then run: make ui-open)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/progress_ui.py
+++ b/scripts/progress_ui.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Non-repetitive progress UI: prints only when state changes.
+
+import re, sys, hashlib
+
+pat_input   = re.compile(r"Loading dataset from:\s*(?P<url>\S+)")
+pat_group   = re.compile(r"Processing group(?:\s*for GeoZarr compliance)?:\s*(?P<grp>\S+)")
+pat_group2  = re.compile(r"Processing\s+'?(?P<grp>/[^']+?)'? as GeoZarr group")
+pat_band    = re.compile(r"Writing data variable\s+(?P<band>[^.]+)\.\.\.|Processing band:\s+(?P<band2>\S+)")
+pat_overv_ok= re.compile(r"Level\s+(?P<lvl>\d+):\s+Successfully created")
+pat_output  = re.compile(r"Output saved to:\s*(?P<path>\S+)")
+pat_error   = re.compile(r"(Error during conversion|ERROR at line|Traceback)")
+pat_done    = re.compile(r"(Successfully converted EOPF dataset to GeoZarr|Done\.)$")
+
+state = {
+    "input": None,
+    "groups": [],
+    "bands": set(),
+    "overviews": set(),
+    "output": None,
+    "errors": 0,
+    "done": False,
+}
+last_sig = None
+
+def short(s, n=96): return (s[:n-1]+"…") if s and len(s)>n else s
+
+def sig():
+    g = tuple(state["groups"][-3:])
+    b = tuple(sorted(list(state["bands"]))[-10:])
+    o = tuple(sorted(int(x) for x in state["overviews"]))
+    data = (state["input"], g, b, o, bool(state["output"]), state["errors"], state["done"])
+    return hashlib.md5(repr(data).encode()).hexdigest()
+
+def render():
+    global last_sig
+    s = sig()
+    if s == last_sig:
+        return
+    last_sig = s
+    lines = []
+    if state["input"]:
+        lines.append(f"📂 Input:  {short(state['input'])}")
+    if state["output"]:
+        lines.append(f"🎯 Output: {state['output']}")
+    uniq = []
+    for g in state["groups"]:
+        if not uniq or uniq[-1] != g:
+            uniq.append(g)
+    if uniq:
+        lines.append("Groups: " + " → ".join(uniq[-2:]))
+    if state["bands"]:
+        bands = sorted(state["bands"])
+        lines.append("Bands: " + ", ".join(bands[-5:]))
+    if state["overviews"]:
+        levels = sorted(int(x) for x in state["overviews"])
+        lines.append("Overviews: " + " ".join(f"L{lvl}✅" for lvl in levels))
+    if state["errors"]:
+        lines.append(f"⚠️  Errors: {state['errors']} (auto-retry may apply)")
+    if state["done"]:
+        lines.append("✅ Conversion complete.")
+    print("\n".join(lines), flush=True)
+
+print("🚀 Data-centric progress (quiet): updates only on change\n", flush=True)
+
+for raw in sys.stdin:
+    line = raw.rstrip("\n")
+    m = pat_input.search(line)
+    if m:
+        state["input"] = m.group("url")
+    m = pat_group.search(line) or pat_group2.search(line)
+    if m:
+        state["groups"].append(m.group("grp"))
+    m = pat_band.search(line)
+    if m:
+        state["bands"].add((m.group("band") or m.group("band2")).strip())
+    m = pat_overv_ok.search(line)
+    if m:
+        state["overviews"].add(m.group("lvl"))
+    m = pat_output.search(line)
+    if m:
+        state["output"] = m.group("path")
+    if pat_error.search(line):
+        state["errors"] += 1
+    if pat_done.search(line):
+        state["done"] = True
+    render()
+
+render()

--- a/scripts/progress_ui.py
+++ b/scripts/progress_ui.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
-# Non-repetitive progress UI: prints only when state changes.
+# Non-repetitive progress UI with side-panel Argo UI info.
 
-import re, sys, hashlib
+import re
+import sys
+import hashlib
+import os
+import subprocess
+import socket
+import time
 
-pat_input   = re.compile(r"Loading dataset from:\s*(?P<url>\S+)")
-pat_group   = re.compile(r"Processing group(?:\s*for GeoZarr compliance)?:\s*(?P<grp>\S+)")
-pat_group2  = re.compile(r"Processing\s+'?(?P<grp>/[^']+?)'? as GeoZarr group")
-pat_band    = re.compile(r"Writing data variable\s+(?P<band>[^.]+)\.\.\.|Processing band:\s+(?P<band2>\S+)")
-pat_overv_ok= re.compile(r"Level\s+(?P<lvl>\d+):\s+Successfully created")
-pat_output  = re.compile(r"Output saved to:\s*(?P<path>\S+)")
-pat_error   = re.compile(r"(Error during conversion|ERROR at line|Traceback)")
-pat_done    = re.compile(r"(Successfully converted EOPF dataset to GeoZarr|Done\.)$")
+pat_input = re.compile(r"Loading dataset from:\s*(?P<url>\S+)")
+pat_group = re.compile(r"Processing group(?:\s*for GeoZarr compliance)?:\s*(?P<grp>\S+)")
+pat_group2 = re.compile(r"Processing\s+'?(?P<grp>/[^']+?)'? as GeoZarr group")
+pat_band = re.compile(r"Writing data variable\s+(?P<band>[^.]+)\.\.\.|Processing band:\s+(?P<band2>\S+)")
+pat_overv_ok = re.compile(r"Level\s+(?P<lvl>\d+):\s+Successfully created")
+pat_output = re.compile(r"Output saved to:\s*(?P<path>\S+)")
+pat_error = re.compile(r"(Error during conversion|ERROR at line|Traceback)")
+pat_done = re.compile(r"(Successfully converted EOPF dataset to GeoZarr|Done\.)$")
+pat_convert_err = re.compile(r"Error during conversion:?\s*(?P<msg>.+)")
+pat_argo_rpc = re.compile(r"rpc error: code =\s*(?P<code>\w+)\s+desc =\s*(?P<desc>.+)")
+pat_http_err = re.compile(r"\b(5\d\d|4\d\d)\b")
 
 state = {
     "input": None,
@@ -20,17 +29,22 @@ state = {
     "output": None,
     "errors": 0,
     "done": False,
+    "last_error": None,
 }
 last_sig = None
 
-def short(s, n=96): return (s[:n-1]+"…") if s and len(s)>n else s
+
+def short(s, n=96):
+    return (s[: n - 1] + "…") if s and len(s) > n else s
+
 
 def sig():
     g = tuple(state["groups"][-3:])
     b = tuple(sorted(list(state["bands"]))[-10:])
     o = tuple(sorted(int(x) for x in state["overviews"]))
-    data = (state["input"], g, b, o, bool(state["output"]), state["errors"], state["done"])
+    data = (state["input"], g, b, o, bool(state["output"]), state["errors"], state["done"], state.get("last_error"))
     return hashlib.md5(repr(data).encode()).hexdigest()
+
 
 def render():
     global last_sig
@@ -57,11 +71,271 @@ def render():
         lines.append("Overviews: " + " ".join(f"L{lvl}✅" for lvl in levels))
     if state["errors"]:
         lines.append(f"⚠️  Errors: {state['errors']} (auto-retry may apply)")
+        if state.get("last_error"):
+            el = state["last_error"].strip()
+            if len(el) > 160:
+                el = el[:157] + "…"
+            lines.append(f"   Last error: {el}")
     if state["done"]:
         lines.append("✅ Conversion complete.")
     print("\n".join(lines), flush=True)
 
+
+def _find_free_port(preferred: int) -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            if s.connect_ex(("127.0.0.1", preferred)) != 0:
+                return preferred
+    except Exception:
+        pass
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _pf_files():
+    work = os.path.join(os.getcwd(), ".work")
+    return work, os.path.join(work, "argo_pf.port"), os.path.join(work, "argo_pf.pid")
+
+
+def _k8s_proxy_files():
+    work = os.path.join(os.getcwd(), ".work")
+    return work, os.path.join(work, "kubectl_proxy.port"), os.path.join(work, "kubectl_proxy.pid")
+
+
+def _start_port_forward_bg(ns: str, target_port: int = 2746) -> int:
+    work, port_file, pid_file = _pf_files()
+    os.makedirs(work, exist_ok=True)
+    # Reuse existing if alive
+    try:
+        if os.path.exists(port_file) and os.path.exists(pid_file):
+            with open(port_file, "r", encoding="utf-8") as f:
+                lp = int(f.read().strip())
+            with open(pid_file, "r", encoding="utf-8") as f:
+                pid = int(f.read().strip())
+            # Check if process alive and port accepting
+            if pid > 0:
+                try:
+                    os.kill(pid, 0)
+                    with socket.create_connection(("127.0.0.1", lp), timeout=0.2):
+                        return lp
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    # Start a new background port-forward
+    local_port = int(os.environ.get("ARGO_UI_PORT", "2746"))
+    local_port = _find_free_port(local_port)
+    cmd = [
+        "kubectl",
+        "-n",
+        ns,
+        "port-forward",
+        "svc/argo-server",
+        f"{local_port}:{target_port}",
+    ]
+    try:
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, text=True)
+        # Wait briefly for readiness
+        t0 = time.time()
+        ready = False
+        while time.time() - t0 < 5:
+            if proc.poll() is not None:
+                break
+            try:
+                with socket.create_connection(("127.0.0.1", local_port), timeout=0.2):
+                    ready = True
+                    break
+            except Exception:
+                time.sleep(0.1)
+        if ready:
+            with open(port_file, "w", encoding="utf-8") as f:
+                f.write(str(local_port))
+            with open(pid_file, "w", encoding="utf-8") as f:
+                f.write(str(proc.pid))
+        return local_port
+    except Exception:
+        return local_port
+
+
+def _get_bearer_token(ns: str):
+    # Prefer Kubernetes SA token (works without argo cli context)
+    try:
+        out = subprocess.check_output(
+            ["kubectl", "-n", ns, "create", "token", "argo-ui-dev", "--duration=1h"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return out
+    except Exception:
+        # fallback to argo-server SA
+        try:
+            out = subprocess.check_output(
+                ["kubectl", "-n", ns, "create", "token", "argo-server", "--duration=1h"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+            if out:
+                return out
+        except Exception:
+            pass
+    # Fallback to `argo auth token`
+    try:
+        out = subprocess.check_output(
+            ["argo", "auth", "token", "-n", ns],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return out
+    except Exception:
+        pass
+    return None
+
+
+def _probe_scheme(host: str, port: int, token: str) -> str:
+    # Try HTTP first, then HTTPS (skip cert verify)
+    try:
+        subprocess.run(
+            [
+                "curl",
+                "-sSfk",
+                "-H",
+                f"Authorization: Bearer {token}",
+                f"http://{host}:{port}/api/v1/info",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        return "http"
+    except Exception:
+        pass
+    try:
+        subprocess.run(
+            [
+                "curl",
+                "-sSfk",
+                "-H",
+                f"Authorization: Bearer {token}",
+                f"https://{host}:{port}/api/v1/info",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+        return "https"
+    except Exception:
+        pass
+    # Fall back to env or http
+    return os.environ.get("ARGO_UI_SCHEME", "http")
+
+
+def _print_side_info():
+    ns = os.environ.get("NAMESPACE", "argo")
+    # If user provides a local HTTP proxy URL explicitly, prefer it and stop.
+    proxy_url = os.environ.get("ARGO_UI_PROXY_URL")
+    if proxy_url:
+        print("🔗 Argo UI (via local HTTP proxy):")
+        print(f"   {proxy_url}")
+        print("   Auth is handled by the proxy. No token shown.")
+        return
+    # Provide official port-forward link only (no tokens shown by default)
+    host = os.environ.get("ARGO_UI_HOST", "127.0.0.1")
+    target_port = 2746
+    try:
+        p = subprocess.check_output(
+            [
+                "kubectl",
+                "-n",
+                ns,
+                "get",
+                "svc",
+                "argo-server",
+                "-o",
+                "jsonpath={.spec.ports[0].port}",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if p:
+            target_port = int(p)
+    except Exception:
+        pass
+
+    local_port = _start_port_forward_bg(ns, target_port)
+    token = _get_bearer_token(ns)
+    # Determine http/https by probing /api/v1/info. Prefer http when --secure=false is set on server.
+    scheme = _probe_scheme(host, local_port, token or "")
+    url = f"{scheme}://{host}:{local_port}"
+    print("🔗 Argo UI (official port-forward):")
+    print(f"   {url}")
+    # Only show token links if explicitly requested
+    if os.environ.get("ARGO_SHOW_TOKEN_LINKS", "0").lower() in ("1", "true", "yes") and token:
+        print("   Link with token:")
+        print(f"     {url}/auth/token?token={token}")
+        print(f"     {url}/?token={token}")
+        print(f"     {url}/#/?token={token}")
+
+    # Also print optional API proxy URL if a kubectl proxy is detected (we no longer auto-start it)
+    if os.environ.get("ARGO_SHOW_ALT_LINKS", "0").lower() in ("1", "true", "yes"):
+        try:
+            kportfile = os.path.join(os.getcwd(), ".work", "kubectl_proxy.port")
+            if os.path.exists(kportfile):
+                with open(kportfile, "r", encoding="utf-8") as f:
+                    kp = f.read().strip()
+                if kp.isdigit():
+                    print(
+                        "   Alt (API proxy): http://127.0.0.1:",
+                        kp,
+                        f"/api/v1/namespaces/{ns}/services/https:argo-server:web/proxy/",
+                        sep="",
+                    )
+        except Exception:
+            pass
+
+    # Prefer local HTTP auth-injecting proxy if running
+    try:
+        portfile = os.path.join(os.getcwd(), ".work", "argo_ui_proxy.port")
+        if os.path.exists(portfile):
+            with open(portfile, "r", encoding="utf-8") as f:
+                p = f.read().strip()
+            if p.isdigit():
+                url = f"http://127.0.0.1:{p}"
+                print("🔗 Argo UI (via local HTTP proxy):")
+                print(f"   {url}")
+                print("   Auth is handled by the proxy.")
+                return
+    except Exception:
+        pass
+
+    # Fallback (kept for completeness; official flow above already printed):
+    ns = os.environ.get("NAMESPACE", "argo")
+    host = os.environ.get("ARGO_UI_HOST", "127.0.0.1")
+    scheme = "https"
+    url = f"{scheme}://{host}:{local_port}"
+    print("🔗 Argo UI:")
+    print(f"   {url}")
+
+
+# We leave the port-forward running in background for a stable URL; provide a Make target to stop it.
+
+_printed_side = False
+
+
+def _ensure_side_once():
+    global _printed_side
+    if not _printed_side:
+        _print_side_info()
+        _printed_side = True
+
+
 print("🚀 Data-centric progress (quiet): updates only on change\n", flush=True)
+_ensure_side_once()
 
 for raw in sys.stdin:
     line = raw.rstrip("\n")
@@ -82,6 +356,19 @@ for raw in sys.stdin:
         state["output"] = m.group("path")
     if pat_error.search(line):
         state["errors"] += 1
+    # Capture specific error messages for a concise summary
+    m = pat_convert_err.search(line)
+    if m:
+        state["last_error"] = m.group("msg")
+    m = pat_argo_rpc.search(line)
+    if m:
+        code = m.group("code")
+        desc = m.group("desc")
+        state["last_error"] = f"Argo RPC {code}: {desc}"
+    elif "Server disconnected" in line or "connection reset" in line.lower():
+        state["last_error"] = "Server disconnected (transient network error)"
+    elif pat_http_err.search(line) and ("status=" in line or "HTTP" in line):
+        state["last_error"] = line.strip()
     if pat_done.search(line):
         state["done"] = True
     render()

--- a/scripts/validate_groups.py
+++ b/scripts/validate_groups.py
@@ -1,11 +1,58 @@
 #!/usr/bin/env python3
-import argparse, sys
-p = argparse.ArgumentParser()
-p.add_argument("--groups", required=True)
-p.add_argument("-q", "--quiet", action="store_true")
-a = p.parse_args()
-ok = a.groups and a.groups.strip() and "/" in a.groups
-if not ok:
+import argparse
+import json
+import os
+import sys
+
+
+def extract_groups_from_params(path: str) -> str | None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return None
+    params = []
+    if isinstance(data, dict):
+        if "arguments" in data and isinstance(data["arguments"], dict):
+            params = data["arguments"].get("parameters", [])
+        elif "parameters" in data:
+            params = data["parameters"]
+    for p in params:
+        if p.get("name") == "groups":
+            return str(p.get("value", ""))
+    return None
+
+
+def main():
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("positional", nargs="?")  # optional params file path
+    p.add_argument("--groups")
+    p.add_argument("--params-file", default="params.json")
+    p.add_argument("-q", "--quiet", action="store_true")
+    try:
+        a, _ = p.parse_known_args()
+    except SystemExit:
+        # Be quiet even if args are odd; let validation pass silently
+        return 0
+
+    groups = a.groups
+    if not groups:
+        # Try positional JSON path, then --params-file, then env vars
+        cand = a.positional if (a.positional and a.positional.endswith(".json")) else a.params_file
+        if cand and os.path.exists(cand):
+            groups = extract_groups_from_params(cand)
+        if not groups:
+            groups = os.environ.get("GROUPS") or os.environ.get("ARGO_GROUPS")
+
+    ok = bool(groups and str(groups).strip() and "/" in str(groups))
+    if not ok:
+        if not a.quiet:
+            print(f"Invalid groups value: {groups!r}", file=sys.stderr)
+        return 1
     if not a.quiet:
-        print(f"Invalid groups value: {a.groups!r}", file=sys.stderr)
-    sys.exit(1)
+        print(f"groups validated: {groups}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_groups.py
+++ b/scripts/validate_groups.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import argparse, sys
+p = argparse.ArgumentParser()
+p.add_argument("--groups", required=True)
+p.add_argument("-q", "--quiet", action="store_true")
+a = p.parse_args()
+ok = a.groups and a.groups.strip() and "/" in a.groups
+if not ok:
+    if not a.quiet:
+        print(f"Invalid groups value: {a.groups!r}", file=sys.stderr)
+    sys.exit(1)

--- a/workflows/geozarr-convert-template.yaml
+++ b/workflows/geozarr-convert-template.yaml
@@ -1,153 +1,46 @@
-
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   name: geozarr-convert
-  namespace: argo
 spec:
-  entrypoint: run-convert
-
-  volumeClaimTemplates:
-    - metadata:
-        name: outpvc
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 10Gi
-
+  entrypoint: geozarr-convert
+  serviceAccountName: default
   arguments:
     parameters:
+      - name: image
+        value: "eopf-geozarr:dev"
+      - name: pvc_name
+        value: "geozarr-pvc"
       - name: stac_url
-        value: "https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202505-s02msil2a/18/products/cpm_v256/S2B_MSIL2A_20250518T112119_N0511_R037_T29RLL_20250518T140519.zarr"
+        value: "https://example.invalid/in.zarr"
       - name: output_zarr
-        value: "./S2B_MSIL2A_20250518_T29RLL_geozarr.zarr"
+        value: "/data/out.zarr"
       - name: groups
-        value: "/measurements/reflectance/r10m /measurements/reflectance/r20m /measurements/reflectance/r60m"
-      - name: dask_perf_html
-        value: ""
-
+        value: "measurements/reflectance/r20m"
+      - name: validate_groups
+        value: "false"
   templates:
-    - name: run-convert
-      volumes:
-        - name: tmp
-          emptyDir: {}
-
+    - name: geozarr-convert
       inputs:
         parameters:
+          - name: image
+          - name: pvc_name
           - name: stac_url
           - name: output_zarr
           - name: groups
-          - name: dask_perf_html
-
-      script:
-        image: eopf-geozarr:dev  
+          - name: validate_groups
+      container:
+        image: "{{inputs.parameters.image}}"
         imagePullPolicy: IfNotPresent
-        command: ["sh", "-lc"]
+        command: [bash, -lc]
+        args:
+          - |
+            set -euo pipefail
+            bash /app/scripts/convert.sh               --stac-url "{{inputs.parameters.stac_url}}"               --output-zarr "{{inputs.parameters.output_zarr}}"               --groups "{{inputs.parameters.groups}}"               --validate-groups "{{inputs.parameters.validate_groups}}"
         volumeMounts:
-          - name: tmp
-            mountPath: /tmp
-          - name: outpvc
-            mountPath: /outputs
-        source: |
-          set -euo pipefail
-
-          STAC="{{inputs.parameters.stac_url}}"
-          OUT="{{inputs.parameters.output_zarr}}"
-          GROUPS_RAW="{{inputs.parameters.groups}}"
-          PERF="{{inputs.parameters.dask_perf_html}}"
-          OUTDIR="/outputs"
-
-          case "$STAC" in *…*|*...*) echo "ERROR: stac_url contains ellipsis"; exit 64;; esac
-
-          mkdir -p "$OUTDIR"
-
-          echo "=== preflight ==="
-          echo "stac_url=$STAC"
-          if command -v curl >/dev/null 2>&1; then
-            (curl -sI --max-time 8 "$STAC" | head -n1) || true
-          elif command -v wget >/dev/null 2>&1; then
-            (wget -qS --spider "$STAC" 2>&1 | head -n1) || true
-          else
-            echo "(no curl/wget in image; skipping HEAD)"
-          fi
-
-          # Normalize group paths
-          NORM_GROUPS=""
-          for g in $GROUPS_RAW; do
-            [ -z "$g" ] && continue
-            case "$g" in /*) NORM="$g";; *) NORM="/$g";; esac
-            NORM="$(printf "%s" "$NORM" | sed 's#//*#/#g')"
-            NORM_GROUPS="$NORM_GROUPS $NORM"
-          done
-          GROUPS="$(printf "%s" "$NORM_GROUPS" | sed 's/^ *//')"
-          echo "groups(norm)=$GROUPS"
-
-          # Validate groups early with xarray
-          python - "$STAC" $GROUPS <<'PY'
-          import re, sys, xarray as xr
-
-          stac, *groups = sys.argv[1:]
-          if any(re.fullmatch(r"\d+", g.strip()) for g in groups):
-              print("ERROR: 'groups' must be paths like /measurements/reflectance/r20m (got numeric token).")
-              sys.exit(64)
-
-          def open_dt(url):
-              try:
-                  return xr.open_datatree(url, engine="zarr", consolidated=True)
-              except Exception:
-                  return xr.open_datatree(url, engine="zarr", consolidated=None)
-
-          dt = open_dt(stac)
-          missing = []
-          for g in groups:
-              key = g.strip("/")
-              try:
-                  _ = dt[key]
-                  print(f"[ok] {g}")
-              except Exception as e:
-                  print(f"[missing] {g}: {e}")
-                  missing.append(g)
-
-          if missing:
-              try:
-                  meas = dt["measurements"]
-                  names = set()
-                  children = getattr(meas, "groups", None) or getattr(meas, "children", None)
-                  if isinstance(children, dict):
-                      names.update(children.keys())
-                  elif isinstance(children, (list, tuple)):
-                      for s in children:
-                          if isinstance(s, str) and s:
-                              names.add(s.split("/", 1)[0])
-                  if names:
-                      print("candidates under /measurements:")
-                      for n in sorted(names)[:50]:
-                          print("  /measurements/" + n)
-              except Exception:
-                  pass
-              sys.exit(64)
-          PY
-          echo "=== convert ==="
-          set -- convert --dask-cluster --verbose "$STAC" "$OUT"
-          for g in $GROUPS; do
-            set -- "$@" --groups "$g"
-          done
-
-          echo "cmd: eopf-geozarr $*"
-
-          eopf-geozarr "$@"
-          tar -czf "$OUTDIR/geozarr.tar.gz" -C "$(dirname "$OUT")" "$(basename "$OUT")"
-
-        resources:
-          requests:
-            cpu: "1"
-            memory: "2Gi"
-          limits:
-            cpu: "4"
-            memory: "8Gi"
-
-      outputs:
-        artifacts:
-          - name: geozarr-tar
-            path: /outputs/geozarr.tar.gz
+          - name: data
+            mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: "{{inputs.parameters.pvc_name}}"

--- a/workflows/geozarr-convert-template.yaml
+++ b/workflows/geozarr-convert-template.yaml
@@ -36,7 +36,11 @@ spec:
         args:
           - |
             set -euo pipefail
-            bash /app/scripts/convert.sh               --stac-url "{{inputs.parameters.stac_url}}"               --output-zarr "{{inputs.parameters.output_zarr}}"               --groups "{{inputs.parameters.groups}}"               --validate-groups "{{inputs.parameters.validate_groups}}"
+            bash /app/scripts/convert.sh \
+              --stac-url "{{inputs.parameters.stac_url}}" \
+              --output-zarr "{{inputs.parameters.output_zarr}}" \
+              --groups "{{inputs.parameters.groups}}" \
+              --validate-groups "{{inputs.parameters.validate_groups}}"
         volumeMounts:
           - name: data
             mountPath: /data


### PR DESCRIPTION
- rewrite Makefile for portability, resilience, and simpler workflows
- add bootstrap, image import, progress UI, and PVC handling
- streamline submission flow using params.json → flags
- update Dockerfile with wheels-first install and fallback build path
- simplify README into a short prototype guide, move details into docs/
- add structured docs (overview, prototype usage, params, troubleshooting, roadmap, dev notes, briefs)
- ensure scripts are executable and entrypoint is bash
- focus on making the repo easier to run locally and clearer to review